### PR TITLE
Prevent rounds from continuing past limit

### DIFF
--- a/src/state/useTournament.ts
+++ b/src/state/useTournament.ts
@@ -170,14 +170,15 @@ export const useTournament = create<Store>()(
                         const pb1 = get().getP(b1); pb1.lastPartnerId = b0;
                     }
 
-                    const nextCourts = moveAndReform(s.courts, get().getP);
                     const final = s.round >= s.totalRounds;
+                    const nextCourts = final ? s.courts : moveAndReform(s.courts, get().getP);
 
                     return {
                         ...s,
                         courts: nextCourts.map(c => ({ ...c, result: undefined })),
                         round: final ? s.round : s.round + 1,
-                        timerEndsAt: undefined
+                        timerEndsAt: undefined,
+                        started: final ? false : s.started
                     };
                 }),
 


### PR DESCRIPTION
## Summary
- Stop tournament after the configured number of rounds
- Disable further round progression once the final round is processed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b09170c63c832d95e5f60cae643944