### PR TITLE
feat: elevate panels for sleeker UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Container, Paper, Stack, Typography } from '@mui/material';
+import { Container, Stack, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import SetupPanel from './components/SetupPanel';
 import PlayerList from './components/PlayerList';
@@ -7,6 +7,7 @@ import CourtsGrid from './components/CourtsGrid';
 import StandingsTable from './components/StandingsTable';
 import PayoutsTable from './components/PayoutsTable';
 import { useTournament } from './state/useTournament';
+import Panel from './components/Panel';
 
 export default function App() {
   const started = useTournament(s => s.started);
@@ -26,16 +27,16 @@ export default function App() {
 
       <Grid container spacing={2}>
         <Grid xs={12} md={4}>
-          <Paper sx={{ p: 2 }}>
+          <Panel>
             <SetupPanel />
-          </Paper>
-          <Paper sx={{ p: 2, mt: 2 }}>
+          </Panel>
+          <Panel sx={{ mt: 2 }}>
             <PlayerList />
-          </Paper>
+          </Panel>
         </Grid>
 
         <Grid xs={12} md={8}>
-          <Paper sx={{ p: 2 }}>
+          <Panel>
             <RoundControls />
             {!started && (
               <Typography mt={2} color="text.secondary">
@@ -43,18 +44,18 @@ export default function App() {
               </Typography>
             )}
             <CourtsGrid />
-          </Paper>
+          </Panel>
 
-          <Paper sx={{ p: 2, mt: 2 }}>
+          <Panel sx={{ mt: 2 }}>
             <Typography variant="h6" gutterBottom>
               Standings {started ? `– Round ${round} of ${totalRounds}` : round >= totalRounds && round > 0 ? '– Final Results' : ''}
             </Typography>
             <StandingsTable />
-          </Paper>
+          </Panel>
 
-          <Paper sx={{ p: 2, mt: 2 }}>
+          <Panel sx={{ mt: 2 }}>
             <PayoutsTable />
-          </Paper>
+          </Panel>
         </Grid>
       </Grid>
     </Container>

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,0 +1,25 @@
+import React, { PropsWithChildren } from 'react';
+import Paper from '@mui/material/Paper';
+import { SxProps, Theme } from '@mui/material/styles';
+
+interface PanelProps extends PropsWithChildren {
+  sx?: SxProps<Theme>;
+}
+
+export default function Panel({ children, sx }: PanelProps) {
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        boxShadow: 3,
+        transition: 'box-shadow 0.3s ease-in-out',
+        '&:hover': { boxShadow: 6 },
+        ...sx,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}


### PR DESCRIPTION
## Summary
- style tournament panels with elevated shadows and hover transitions
- refactor layout to use reusable Panel component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b09f5f2db0832d8009ba3d03e8d7ca