### PR TITLE
feat: fetch DUPR ratings for players

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A React + TypeScript web app to run a **King-of-the-Court style pickleball tourn
 
 ## Features
 - Add 12–40 players with DUPR ratings (4 per court × 10 courts)
+- Automatic DUPR rating lookup by player name
 - Courts seeded by rating
 - Set entry fee (default $30)
 - Automatic payout calculations with customizable % split

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,7 +1,8 @@
 import { Button, Divider, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Stack, TextField, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useTournament } from '../state/useTournament';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { fetchDUPRRating } from '../utils/dupr';
 
 export default function PlayerList() {
     const players = useTournament(s => s.players);
@@ -22,6 +23,15 @@ export default function PlayerList() {
         setName('');
         setRating('');
     };
+
+    useEffect(() => {
+        if (!name.trim()) { setRating(''); return; }
+        const timer = setTimeout(async () => {
+            const r = await fetchDUPRRating(name);
+            if (r !== null) setRating(r.toString());
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [name]);
 
     return (
         <Stack spacing={1.5}>

--- a/src/utils/dupr.ts
+++ b/src/utils/dupr.ts
@@ -1,0 +1,34 @@
+export const DUPR_CLIENT_ID = '6116991916';
+export const DUPR_KEY_ID = '5616016501';
+export const DUPR_CLIENT_KEY = 'test-ck-0f3d03ec-02bb-436d-fceb-7848797ed42a';
+export const DUPR_CLIENT_SECRET = 'test-cs-04dd90d84c074ec6fc3d6f692590f022';
+
+interface PlayerSearchResult {
+    players?: Array<{ id: string; name: string; rating?: number }>; // simplified
+}
+
+/**
+ * Fetch a player's DUPR rating by name from the DUPR test environment.
+ * Returns the player's rating if found, otherwise null.
+ */
+export async function fetchDUPRRating(name: string): Promise<number | null> {
+    if (!name.trim()) return null;
+    try {
+        const url = `https://uat.dupr.gg/api/v1/players/search?name=${encodeURIComponent(name)}`;
+        const res = await fetch(url, {
+            headers: {
+                'x-client-id': DUPR_CLIENT_ID,
+                'x-key-id': DUPR_KEY_ID,
+                'x-client-key': DUPR_CLIENT_KEY,
+                'x-client-secret': DUPR_CLIENT_SECRET
+            }
+        });
+        if (!res.ok) return null;
+        const data = await res.json() as PlayerSearchResult;
+        const player = data.players && data.players[0];
+        return player && typeof player.rating === 'number' ? player.rating : null;
+    } catch (err) {
+        console.error('Error fetching DUPR rating', err);
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add DUPR client utility with UAT credentials
- auto-load DUPR rating when player name is entered
- document automatic DUPR lookup in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2bdbe64832d9b0a250c05a01776