### PR TITLE
refactor: apply clean code principles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,17 @@ import { useTournament } from './state/useTournament';
 import Panel from './components/Panel';
 
 export default function App() {
-  const started = useTournament(s => s.started);
-  const round = useTournament(s => s.round);
-  const totalRounds = useTournament(s => s.totalRounds);
+  const { started, round, totalRounds } = useTournament(s => ({
+    started: s.started,
+    round: s.round,
+    totalRounds: s.totalRounds,
+  }));
+
+  const standingsLabel = started
+    ? `– Round ${round} of ${totalRounds}`
+    : round >= totalRounds && round > 0
+      ? '– Final Results'
+      : '';
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -21,7 +29,8 @@ export default function App() {
           King-of-the-Court Tournament (10 Courts)
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          Winner-up / loser-down (Ct 1 winners & top-court losers stay). Partner mixing reduces repeat partners. Data persists in your browser.
+          Winner-up / loser-down (Ct 1 winners & top-court losers stay). Partner
+          mixing reduces repeat partners. Data persists in your browser.
         </Typography>
       </Stack>
 
@@ -48,7 +57,7 @@ export default function App() {
 
           <Panel sx={{ mt: 2 }}>
             <Typography variant="h6" gutterBottom>
-              Standings {started ? `– Round ${round} of ${totalRounds}` : round >= totalRounds && round > 0 ? '– Final Results' : ''}
+              Standings {standingsLabel}
             </Typography>
             <StandingsTable />
           </Panel>

--- a/src/components/CourtsGrid.tsx
+++ b/src/components/CourtsGrid.tsx
@@ -1,40 +1,53 @@
-import { Card, CardContent, FormControlLabel, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+import {
+    Card,
+    CardContent,
+    FormControlLabel,
+    Radio,
+    RadioGroup,
+    Stack,
+    Typography,
+} from '@mui/material';
 import Grid from '@mui/material/Grid';
+import { useMemo } from 'react';
 import { useTournament } from '../state/useTournament';
 import type { ResultMark } from '../types';
-
-const teamLabel = (ids: string[], getName: (id: string) => string) =>
-    ids.map(getName).join(' & ');
 
 export default function CourtsGrid() {
     const courts = useTournament(s => s.courts);
     const players = useTournament(s => s.players);
-    const mark = useTournament(s => s.markCourtResult);
+    const markResult = useTournament(s => s.markCourtResult);
 
-    const getName = (id: string) => players.find(p => p.id === id)?.name ?? 'Unknown';
+    const nameMap = useMemo(() => {
+        const map: Record<string, string> = {};
+        players.forEach(p => { map[p.id] = p.name; });
+        return map;
+    }, [players]);
+
+    const formatTeam = (ids: string[]) =>
+        ids.map(id => nameMap[id] ?? 'Unknown').join(' & ');
 
     if (!courts.length) return null;
 
     return (
         <Grid container spacing={2} sx={{ mt: 2 }}>
-            {courts.map(c => (
-                <Grid key={c.court} xs={12} sm={6} md={4}>
+            {courts.map(court => (
+                <Grid key={court.court} xs={12} sm={6} md={4}>
                     <Card variant="outlined">
                         <CardContent>
                             <Typography variant="subtitle1" fontWeight={700} gutterBottom>
-                                Court {c.court}
+                                Court {court.court}
                             </Typography>
                             <Stack spacing={1}>
                                 <Typography variant="body2">
-                                    <strong>A:</strong> {teamLabel(c.teamA, getName)}
+                                    <strong>A:</strong> {formatTeam(court.teamA)}
                                 </Typography>
                                 <Typography variant="body2">
-                                    <strong>B:</strong> {teamLabel(c.teamB, getName)}
+                                    <strong>B:</strong> {formatTeam(court.teamB)}
                                 </Typography>
                                 <RadioGroup
                                     row
-                                    value={c.result ?? ''}
-                                    onChange={(_, v) => mark(c.court, v as ResultMark)}
+                                    value={court.result ?? ''}
+                                    onChange={(_, v) => markResult(court.court, v as ResultMark)}
                                 >
                                     <FormControlLabel value="A" control={<Radio />} label="A won" />
                                     <FormControlLabel value="B" control={<Radio />} label="B won" />

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import Paper from '@mui/material/Paper';
 import { SxProps, Theme } from '@mui/material/styles';
 

--- a/src/components/PayoutsTable.tsx
+++ b/src/components/PayoutsTable.tsx
@@ -1,22 +1,23 @@
 import { Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 import { useTournament } from '../state/useTournament';
 
-const currency = (n: number) => '$' + Math.round(n).toLocaleString();
+const formatCurrency = (n: number) => '$' + Math.round(n).toLocaleString();
 
 export default function PayoutsTable() {
-    const entry = useTournament(s => s.entryFee);
-    const count = useTournament(s => s.players.length);
-    const split = useTournament(s => s.payoutPercents);
+    const entryFee = useTournament(s => s.entryFee);
+    const playerCount = useTournament(s => s.players.length);
+    const payoutSplit = useTournament(s => s.payoutPercents);
     const { totalPot, places } = useTournament(s => s.payouts());
 
-    if (!count) return null;
+    if (!playerCount) return null;
 
     return (
         <Stack spacing={1}>
             <Typography variant="h6">Payouts</Typography>
             <Typography variant="body2" color="text.secondary">
-                {count} players × ${entry} entry = <strong>{currency(totalPot)}</strong> |
-                Split: {split.map(p => Math.round(p)).join('% / ')}%
+                {playerCount} players × ${entryFee} entry ={' '}
+                <strong>{formatCurrency(totalPot)}</strong> | Split:{' '}
+                {payoutSplit.map(p => Math.round(p)).join('% / ')}%
             </Typography>
             <Table size="small">
                 <TableHead>
@@ -27,11 +28,11 @@ export default function PayoutsTable() {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {places.map(p => (
-                        <TableRow key={p.place}>
-                            <TableCell>{p.place}</TableCell>
-                            <TableCell>{p.player?.name ?? '—'}</TableCell>
-                            <TableCell align="right">{currency(p.amount)}</TableCell>
+                    {places.map(place => (
+                        <TableRow key={place.place}>
+                            <TableCell>{place.place}</TableCell>
+                            <TableCell>{place.player?.name ?? '—'}</TableCell>
+                            <TableCell align="right">{formatCurrency(place.amount)}</TableCell>
                         </TableRow>
                     ))}
                 </TableBody>

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,7 +1,18 @@
-import { Button, Divider, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Stack, TextField, Typography } from '@mui/material';
+import {
+    Button,
+    Divider,
+    IconButton,
+    List,
+    ListItem,
+    ListItemSecondaryAction,
+    ListItemText,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useTournament } from '../state/useTournament';
 import { useEffect, useState } from 'react';
+import { useTournament } from '../state/useTournament';
 import { fetchDUPRRating } from '../utils/dupr';
 
 export default function PlayerList() {
@@ -13,22 +24,35 @@ export default function PlayerList() {
     const [name, setName] = useState('');
     const [rating, setRating] = useState('');
 
-    const onAdd = () => {
-        const n = name.trim();
-        const r = Number(rating);
-        if (!n || isNaN(r)) return;
-        if (players.length >= 40) { alert('Max 40 players (10 courts × 4).'); return; }
-        if (players.some(p => p.name.toLowerCase() === n.toLowerCase())) { alert('Name already added.'); return; }
-        add(n, r);
+    const handleAdd = () => {
+        const trimmedName = name.trim();
+        const numericRating = Number(rating);
+        if (!trimmedName || isNaN(numericRating)) return;
+        if (players.length >= 40) {
+            alert('Max 40 players (10 courts × 4).');
+            return;
+        }
+        const exists = players.some(
+            p => p.name.toLowerCase() === trimmedName.toLowerCase()
+        );
+        if (exists) {
+            alert('Name already added.');
+            return;
+        }
+        add(trimmedName, numericRating);
         setName('');
         setRating('');
     };
 
     useEffect(() => {
-        if (!name.trim()) { setRating(''); return; }
+        const trimmedName = name.trim();
+        if (!trimmedName) {
+            setRating('');
+            return;
+        }
         const timer = setTimeout(async () => {
-            const r = await fetchDUPRRating(name);
-            if (r !== null) setRating(r.toString());
+            const fetched = await fetchDUPRRating(trimmedName);
+            if (fetched !== null) setRating(fetched.toString());
         }, 500);
         return () => clearTimeout(timer);
     }, [name]);
@@ -43,7 +67,9 @@ export default function PlayerList() {
                     onChange={e => setName(e.target.value)}
                     size="small"
                     fullWidth
-                    onKeyDown={e => { if (e.key === 'Enter') onAdd(); }}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter') handleAdd();
+                    }}
                 />
                 <TextField
                     label="DUPR"
@@ -51,9 +77,13 @@ export default function PlayerList() {
                     onChange={e => setRating(e.target.value)}
                     size="small"
                     sx={{ width: 100 }}
-                    onKeyDown={e => { if (e.key === 'Enter') onAdd(); }}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter') handleAdd();
+                    }}
                 />
-                <Button onClick={onAdd} variant="contained" disabled={started}>Add</Button>
+                <Button onClick={handleAdd} variant="contained" disabled={started}>
+                    Add
+                </Button>
             </Stack>
             <Typography variant="body2" color="text.secondary">Count must be 12-40 and a multiple of 4 to start.</Typography>
             <Divider />

--- a/src/components/RoundControls.tsx
+++ b/src/components/RoundControls.tsx
@@ -8,17 +8,23 @@ export default function RoundControls() {
     const courts = useTournament(s => s.courts);
     const nextRound = useTournament(s => s.nextRound);
 
-    const allResults = courts.length > 0 && courts.every(c => c.result);
-    const label = started ? `Round ${round}` : round >= totalRounds && round > 0 ? 'Finished' : 'Not started';
+    const allResultsSubmitted = courts.length > 0 && courts.every(c => c.result);
+    const statusLabel = started
+        ? `Round ${round}`
+        : round >= totalRounds && round > 0
+            ? 'Finished'
+            : 'Not started';
 
     return (
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
             <Stack direction="row" spacing={1} alignItems="center">
-                <Chip label={label} color={started ? 'primary' : 'default'} />
+                <Chip label={statusLabel} color={started ? 'primary' : 'default'} />
                 <Typography variant="body2" color="text.secondary">of {totalRounds}</Typography>
             </Stack>
             <Stack direction="row" spacing={1}>
-                <Button onClick={nextRound} variant="contained" disabled={!started || !allResults}>Next Round</Button>
+                <Button onClick={nextRound} variant="contained" disabled={!started || !allResultsSubmitted}>
+                    Next Round
+                </Button>
             </Stack>
         </Stack>
     );

--- a/src/components/SetupPanel.tsx
+++ b/src/components/SetupPanel.tsx
@@ -1,15 +1,23 @@
 import { Button, Stack, TextField, Typography } from '@mui/material';
-import { useTournament } from '../state/useTournament';
 import { useState } from 'react';
+import { useTournament } from '../state/useTournament';
 
 export default function SetupPanel() {
-    const { maxCourts, totalRounds, entryFee, payoutPercents, started } = useTournament();
-    const setConfig = useTournament(s => s.setConfig);
-    const start = useTournament(s => s.startTournament);
-    const reset = useTournament(s => s.reset);
-    const canStart = useTournament(s => s.canStart);
+    const {
+        maxCourts,
+        totalRounds,
+        entryFee,
+        payoutPercents,
+        started,
+        setConfig,
+        startTournament,
+        reset,
+        canStart,
+    } = useTournament();
 
-    const [splitText, setSplitText] = useState(payoutPercents.map(p => Math.round(p)).join(','));
+    const [payoutText, setPayoutText] = useState(
+        payoutPercents.map(p => Math.round(p)).join(',')
+    );
 
     return (
         <Stack spacing={1.5}>
@@ -38,16 +46,23 @@ export default function SetupPanel() {
             />
             <TextField
                 label="Payout Split (%) e.g. 50,30,20"
-                value={splitText}
-                onChange={e => setSplitText(e.target.value)}
+                value={payoutText}
+                onChange={e => setPayoutText(e.target.value)}
                 onBlur={() => {
-                    const arr = splitText.split(',').map(s => Number(s.trim())).filter(n => !isNaN(n) && n > 0);
-                    setConfig({ payoutPercents: arr.length ? arr : [50, 30, 20] });
+                    const split = payoutText
+                        .split(',')
+                        .map(s => Number(s.trim()))
+                        .filter(n => !isNaN(n) && n > 0);
+                    setConfig({ payoutPercents: split.length ? split : [50, 30, 20] });
                 }}
                 size="small"
             />
             <Stack direction="row" spacing={1}>
-                <Button variant="contained" onClick={start} disabled={!canStart()}>
+                <Button
+                    variant="contained"
+                    onClick={startTournament}
+                    disabled={!canStart()}
+                >
                     Start Tournament
                 </Button>
                 <Button variant="outlined" color="error" onClick={reset}>

--- a/src/components/StandingsTable.tsx
+++ b/src/components/StandingsTable.tsx
@@ -3,28 +3,25 @@ import { useTournament } from '../state/useTournament';
 import { exportCSV } from '../utils/csv';
 
 export default function StandingsTable() {
-    const standings = useTournament(s => s.standings());
+    const standingsList = useTournament(s => s.standings());
     const players = useTournament(s => s.players);
 
     if (!players.length) return null;
 
-    const onExport = () => {
+    const exportStandings = () => {
         const rows: string[][] = [
-            ['Rank', 'Player', 'Points', 'W', 'L', 'Court1 Finishes']
-        ];
-        standings.forEach((p, i) =>
-            rows.push([
+            ['Rank', 'Player', 'Points', 'W', 'L', 'Court1 Finishes'],
+            ...standingsList.map((p, i) => [
                 String(i + 1),
                 p.name,
                 String(p.points),
                 String(p.wins),
                 String(p.losses),
-                String(p.court1Finishes)
-            ])
-        );
+                String(p.court1Finishes),
+            ]),
+        ];
         exportCSV('standings.csv', rows);
     };
-
 
     return (
         <>
@@ -40,7 +37,7 @@ export default function StandingsTable() {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {standings.map((p, i) => (
+                    {standingsList.map((p, i) => (
                         <TableRow key={p.id}>
                             <TableCell>{i + 1}</TableCell>
                             <TableCell>{p.name}</TableCell>
@@ -52,7 +49,9 @@ export default function StandingsTable() {
                     ))}
                 </TableBody>
             </Table>
-            <Button sx={{ mt: 1 }} onClick={onExport}>Export CSV</Button>
+            <Button sx={{ mt: 1 }} onClick={exportStandings}>
+                Export CSV
+            </Button>
         </>
     );
 }

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,20 +1,24 @@
 export function exportCSV(filename: string, rows: (string | number)[][]) {
-    const csv = rows
-        .map(r =>
-            r.map(cell => {
-                const s = String(cell ?? '');
-                return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-            }).join(',')
+    const csvContent = rows
+        .map(row =>
+            row
+                .map(cell => {
+                    const value = String(cell ?? '');
+                    return /[",\n]/.test(value)
+                        ? `"${value.replace(/"/g, '""')}"`
+                        : value;
+                })
+                .join(',')
         )
         .join('\n');
 
-    const blob = new Blob([csv], { type: 'text/csv;charset=UTF-8;' });
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=UTF-8;' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
     URL.revokeObjectURL(url);
 }

--- a/src/utils/dupr.ts
+++ b/src/utils/dupr.ts
@@ -15,20 +15,20 @@ export async function fetchDUPRRating(name: string): Promise<number | null> {
     if (!name.trim()) return null;
     try {
         const url = `https://uat.dupr.gg/api/v1/players/search?name=${encodeURIComponent(name)}`;
-        const res = await fetch(url, {
+        const response = await fetch(url, {
             headers: {
                 'x-client-id': DUPR_CLIENT_ID,
                 'x-key-id': DUPR_KEY_ID,
                 'x-client-key': DUPR_CLIENT_KEY,
-                'x-client-secret': DUPR_CLIENT_SECRET
-            }
+                'x-client-secret': DUPR_CLIENT_SECRET,
+            },
         });
-        if (!res.ok) return null;
-        const data = await res.json() as PlayerSearchResult;
+        if (!response.ok) return null;
+        const data: PlayerSearchResult = await response.json();
         const player = data.players && data.players[0];
         return player && typeof player.rating === 'number' ? player.rating : null;
-    } catch (err) {
-        console.error('Error fetching DUPR rating', err);
+    } catch (error) {
+        console.error('Error fetching DUPR rating', error);
         return null;
     }
 }

--- a/src/utils/rotation.ts
+++ b/src/utils/rotation.ts
@@ -26,35 +26,40 @@ export function seedInitialCourts(players: Player[], courts: number): CourtState
 
 export function formTeamsAvoidingRepeat(
     participants: string[],
-    getP: (id: string) => Player
+    getPlayer: (id: string) => Player
 ): { A: string[]; B: string[] } {
     if (participants.length !== 4) {
         return { A: participants.slice(0, 2), B: participants.slice(2, 4) };
     }
-    const perms: string[][] = [
+    const permutations: string[][] = [
         [participants[0], participants[1], participants[2], participants[3]],
         [participants[0], participants[2], participants[1], participants[3]],
         [participants[0], participants[3], participants[1], participants[2]],
     ];
-    const score = (p: string[]) => {
-        const a = [p[0], p[1]], b = [p[2], p[3]];
-        const p0 = getP(a[0]).lastPartnerId === a[1] ? 1 : 0;
-        const p1 = getP(a[1]).lastPartnerId === a[0] ? 1 : 0;
-        const p2 = getP(b[0]).lastPartnerId === b[1] ? 1 : 0;
-        const p3 = getP(b[1]).lastPartnerId === b[0] ? 1 : 0;
+    const score = (combo: string[]) => {
+        const a = [combo[0], combo[1]];
+        const b = [combo[2], combo[3]];
+        const p0 = getPlayer(a[0]).lastPartnerId === a[1] ? 1 : 0;
+        const p1 = getPlayer(a[1]).lastPartnerId === a[0] ? 1 : 0;
+        const p2 = getPlayer(b[0]).lastPartnerId === b[1] ? 1 : 0;
+        const p3 = getPlayer(b[1]).lastPartnerId === b[0] ? 1 : 0;
         return p0 + p1 + p2 + p3;
     };
-    let best = perms[0], bestScore = score(perms[0]);
-    for (let i = 1; i < perms.length; i++) {
-        const s = score(perms[i]);
-        if (s < bestScore) { best = perms[i]; bestScore = s; }
+    let best = permutations[0];
+    let bestScore = score(permutations[0]);
+    for (let i = 1; i < permutations.length; i++) {
+        const s = score(permutations[i]);
+        if (s < bestScore) {
+            best = permutations[i];
+            bestScore = s;
+        }
     }
     return { A: [best[0], best[1]], B: [best[2], best[3]] };
 }
 
 export function moveAndReform(
     courts: CourtState[],
-    getP: (id: string) => Player
+    getPlayer: (id: string) => Player
 ): CourtState[] {
     const top = courts.length;
     const arrivals: Record<number, string[]> = {};
@@ -79,7 +84,7 @@ export function moveAndReform(
             next.push({ court: c, teamA: prev.teamA.slice(), teamB: prev.teamB.slice() });
             continue;
         }
-        const { A, B } = formTeamsAvoidingRepeat(ids, getP);
+        const { A, B } = formTeamsAvoidingRepeat(ids, getPlayer);
         next.push({ court: c, teamA: A, teamB: B });
     }
     return next;


### PR DESCRIPTION
## Summary
- streamline tournament app state management and naming for clarity
- improve component readability and derived labels
- refactor utilities for explicit behavior and better variable naming

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a49f956c832d83889996cc910944