### PR TITLE
Add browser headers for DUPR API calls

### DIFF
--- a/backend/src/main/java/com/example/smashboard/service/DuprAuthService.java
+++ b/backend/src/main/java/com/example/smashboard/service/DuprAuthService.java
@@ -5,7 +5,8 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -26,13 +27,18 @@ public class DuprAuthService {
 
         String url = "https://api.dupr.gg/auth/v1.0/login";
 
-        // ✅ Use LinkedHashMap / HashMap to ensure JSON shape matches browser request
-        Map<String, String> request = new HashMap<>();
+        // Use LinkedHashMap to maintain field order similar to browser request
+        Map<String, String> request = new LinkedHashMap<>();
         request.put("email", duprEmail);
         request.put("password", duprPassword);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set("Origin", "https://dashboard.dupr.com");
+        headers.set("Referer", "https://dashboard.dupr.com/");
+        headers.set(HttpHeaders.USER_AGENT,
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36");
 
         HttpEntity<Map<String, String>> entity = new HttpEntity<>(request, headers);
 

--- a/backend/src/main/java/com/example/smashboard/service/DuprClubService.java
+++ b/backend/src/main/java/com/example/smashboard/service/DuprClubService.java
@@ -4,6 +4,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +19,11 @@ public class DuprClubService {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(token);
         headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set("Origin", "https://dashboard.dupr.com");
+        headers.set("Referer", "https://dashboard.dupr.com/");
+        headers.set(HttpHeaders.USER_AGENT,
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36");
 
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 


### PR DESCRIPTION
## Summary
- send DUPR login request with browser-like headers and ordered JSON body
- mirror browser headers for club member requests

## Testing
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b21f48576c832da0f5109c4ea90af6