### PR TITLE
Simplify payouts and widen player search

### DIFF
--- a/frontend/src/components/PayoutsTable.tsx
+++ b/frontend/src/components/PayoutsTable.tsx
@@ -6,7 +6,6 @@ const formatCurrency = (n: number) => '$' + Math.round(n).toLocaleString();
 export default function PayoutsTable() {
     const entryFee = useTournament(s => s.entryFee);
     const playerCount = useTournament(s => s.players.length);
-    const payoutSplit = useTournament(s => s.payoutPercents);
     const { totalPot, payoutPool, places } = useTournament(s => s.payouts());
     const poolPercent = totalPot ? Math.round((payoutPool / totalPot) * 100) : 0;
 
@@ -18,8 +17,7 @@ export default function PayoutsTable() {
             <Typography variant="body2" color="text.secondary">
                 {playerCount} players × ${entryFee} entry ={' '}
                 <strong>{formatCurrency(totalPot)}</strong> | Payout pool ({poolPercent}%):{' '}
-                <strong>{formatCurrency(payoutPool)}</strong> | Split:{' '}
-                {payoutSplit.map(p => Math.round(p)).join('% / ')}%
+                <strong>{formatCurrency(payoutPool)}</strong>
             </Typography>
             <Table size="small">
                 <TableHead>

--- a/frontend/src/components/PlayerList.tsx
+++ b/frontend/src/components/PlayerList.tsx
@@ -81,6 +81,8 @@ export default function PlayerList() {
                         />
                     )}
                     disabled={started}
+                    fullWidth
+                    sx={{ flexGrow: 1 }}
                 />
                 <TextField
                     label="DUPR"

--- a/frontend/src/components/SetupPanel.tsx
+++ b/frontend/src/components/SetupPanel.tsx
@@ -1,5 +1,4 @@
 import { Button, Stack, TextField, Typography } from '@mui/material';
-import { useState } from 'react';
 import { useTournament } from '../state/useTournament';
 
 export default function SetupPanel() {
@@ -7,17 +6,12 @@ export default function SetupPanel() {
         maxCourts,
         totalRounds,
         entryFee,
-        payoutPercents,
         started,
         setConfig,
         startTournament,
         reset,
         canStart,
     } = useTournament();
-
-    const [payoutText, setPayoutText] = useState(
-        payoutPercents.map(p => Math.round(p)).join(',')
-    );
 
     return (
         <Stack spacing={1.5}>
@@ -42,19 +36,6 @@ export default function SetupPanel() {
                 type="number"
                 value={entryFee}
                 onChange={e => setConfig({ entryFee: Math.max(0, Number(e.target.value || 30)) })}
-                size="small"
-            />
-            <TextField
-                label="Payout Split (%) e.g. 30,20,10"
-                value={payoutText}
-                onChange={e => setPayoutText(e.target.value)}
-                onBlur={() => {
-                    const split = payoutText
-                        .split(',')
-                        .map(s => Number(s.trim()))
-                        .filter(n => !isNaN(n) && n > 0);
-                    setConfig({ payoutPercents: split.length ? split : [30, 20, 10] });
-                }}
                 size="small"
             />
             <Stack direction="row" spacing={1}>

--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -11,7 +11,7 @@ type Store = TournamentState & {
     removePlayer: (id: string) => void;
     reset: () => void;
     setConfig: (cfg: Partial<Pick<TournamentState,
-        'maxCourts' | 'totalRounds' | 'entryFee' | 'payoutPercents'>>) => void;
+        'maxCourts' | 'totalRounds' | 'entryFee'>>) => void;
     startTournament: () => void;
     markCourtResult: (court: number, result: ResultMark) => void;
     clearRoundResults: () => void;
@@ -23,11 +23,6 @@ type Store = TournamentState & {
     getPlayer: (id: string) => Player;
 };
 
-const sanitizePayoutSplit = (arr: number[]) => {
-    const positive = arr.filter(n => n > 0);
-    return positive.length ? positive : [30, 20, 10];
-};
-
 export const useTournament = create<Store>()(
     persist(
         (set, get) => ({
@@ -36,7 +31,6 @@ export const useTournament = create<Store>()(
             round: 0,
             totalRounds: 8,
             entryFee: 30,
-            payoutPercents: [30, 20, 10],
             started: false,
             maxCourts: 10,
 
@@ -71,7 +65,6 @@ export const useTournament = create<Store>()(
                 round: 0,
                 totalRounds: 8,
                 entryFee: 30,
-                payoutPercents: [30, 20, 10],
                 started: false,
                 maxCourts: 10
             })),
@@ -80,9 +73,6 @@ export const useTournament = create<Store>()(
                 set(s => ({
                     ...s,
                     ...cfg,
-                    payoutPercents: cfg.payoutPercents
-                        ? sanitizePayoutSplit(cfg.payoutPercents)
-                        : s.payoutPercents,
                 })),
 
             requiredCourts: () => {
@@ -184,11 +174,11 @@ export const useTournament = create<Store>()(
                 const s = get();
                 const totalPot = s.players.length * s.entryFee;
                 const payoutPool = totalPot * 0.5;
-                const sum = s.payoutPercents.reduce((a, b) => a + b, 0) || 1;
-                const places = s.payoutPercents.map((pct, i) => ({
+                const payoutPercents = [50, 30, 20];
+                const places = payoutPercents.map((pct, i) => ({
                     place: i + 1,
                     player: get().standings()[i],
-                    amount: Math.round(payoutPool * (pct / sum))
+                    amount: Math.round(payoutPool * (pct / 100))
                 }));
                 return { totalPot, payoutPool, places };
             }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -25,7 +25,6 @@ export type TournamentState = {
   round: number;
   totalRounds: number;
   entryFee: number;
-  payoutPercents: number[];
   started: boolean;
   maxCourts: number;
 };


### PR DESCRIPTION
## Summary
- Drop payout split configuration and always pay out half the entry pot
- Widen player search bar for easier navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b45ed83df0832dab5107995de1a689