### PR TITLE
feat: track game scores and point differential

### DIFF
--- a/frontend/src/components/CourtsGrid.tsx
+++ b/frontend/src/components/CourtsGrid.tsx
@@ -1,16 +1,13 @@
 import {
     Card,
     CardContent,
-    FormControlLabel,
-    Radio,
-    RadioGroup,
     Stack,
     Typography,
+    TextField,
 } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useMemo } from 'react';
 import { useTournament } from '../state/useTournament';
-import type { ResultMark } from '../types';
 
 export default function CourtsGrid() {
     const courts = useTournament(s => s.courts);
@@ -44,14 +41,26 @@ export default function CourtsGrid() {
                                 <Typography variant="body2">
                                     <strong>B:</strong> {formatTeam(court.teamB)}
                                 </Typography>
-                                <RadioGroup
-                                    row
-                                    value={court.result ?? ''}
-                                    onChange={(_, v) => markResult(court.court, v as ResultMark)}
-                                >
-                                    <FormControlLabel value="A" control={<Radio />} label="A won" />
-                                    <FormControlLabel value="B" control={<Radio />} label="B won" />
-                                </RadioGroup>
+                                <Stack direction="row" spacing={1}>
+                                    <TextField
+                                        label="A"
+                                        type="number"
+                                        size="small"
+                                        value={court.scoreA ?? ''}
+                                        onChange={e => markResult(court.court, { scoreA: e.target.value === '' ? undefined : Number(e.target.value) })}
+                                        inputProps={{ min: 0 }}
+                                        sx={{ width: 60 }}
+                                    />
+                                    <TextField
+                                        label="B"
+                                        type="number"
+                                        size="small"
+                                        value={court.scoreB ?? ''}
+                                        onChange={e => markResult(court.court, { scoreB: e.target.value === '' ? undefined : Number(e.target.value) })}
+                                        inputProps={{ min: 0 }}
+                                        sx={{ width: 60 }}
+                                    />
+                                </Stack>
                             </Stack>
                         </CardContent>
                     </Card>

--- a/frontend/src/components/RoundControls.tsx
+++ b/frontend/src/components/RoundControls.tsx
@@ -8,7 +8,11 @@ export default function RoundControls() {
     const courts = useTournament(s => s.courts);
     const nextRound = useTournament(s => s.nextRound);
 
-    const allResultsSubmitted = courts.length > 0 && courts.every(c => c.result);
+    const allResultsSubmitted = courts.length > 0 && courts.every(c =>
+        c.scoreA !== undefined &&
+        c.scoreB !== undefined &&
+        ((c.scoreA >= 11 || c.scoreB >= 11) && Math.abs(c.scoreA - c.scoreB) >= 2)
+    );
     const statusLabel = started
         ? `Round ${round}`
         : round >= totalRounds && round > 0

--- a/frontend/src/components/SetupPanel.tsx
+++ b/frontend/src/components/SetupPanel.tsx
@@ -17,18 +17,17 @@ export default function SetupPanel() {
         <Stack spacing={1.5}>
             <Typography variant="h6">Setup</Typography>
             <TextField
-                label="Number of Courts (max 10)"
+                label="Number of Courts"
                 type="number"
                 value={maxCourts}
-                onChange={e => setConfig({ maxCourts: Math.max(1, Math.min(10, Number(e.target.value || 10))) })}
-                disabled={started}
+                disabled
                 size="small"
             />
             <TextField
                 label="Total Rounds"
                 type="number"
                 value={totalRounds}
-                onChange={e => setConfig({ totalRounds: Math.max(1, Math.min(50, Number(e.target.value || 8))) })}
+                disabled
                 size="small"
             />
             <TextField

--- a/frontend/src/components/StandingsTable.tsx
+++ b/frontend/src/components/StandingsTable.tsx
@@ -10,7 +10,7 @@ export default function StandingsTable() {
 
     const exportStandings = () => {
         const rows: string[][] = [
-            ['Rank', 'Player', 'Points', 'Wins', 'Losses', 'Pts Won', 'Pts Lost', 'Balance'],
+            ['Rank', 'Player', 'Points', 'Wins', 'Losses', 'Pts Won', 'Pts Lost', 'Diff', 'Balance'],
             ...standingsList.map((player, i) => [
                 String(i + 1),
                 player.name,
@@ -19,6 +19,7 @@ export default function StandingsTable() {
                 String(player.losses),
                 String(player.pointsWon),
                 String(player.pointsLost),
+                String(player.pointsWon - player.pointsLost),
                 String(player.balance),
             ]),
         ];
@@ -37,6 +38,7 @@ export default function StandingsTable() {
                         <TableCell>Losses</TableCell>
                         <TableCell>Pts Won</TableCell>
                         <TableCell>Pts Lost</TableCell>
+                        <TableCell>Diff</TableCell>
                         <TableCell>Balance</TableCell>
                     </TableRow>
                 </TableHead>
@@ -50,6 +52,7 @@ export default function StandingsTable() {
                             <TableCell>{player.losses}</TableCell>
                             <TableCell>{player.pointsWon}</TableCell>
                             <TableCell>{player.pointsLost}</TableCell>
+                            <TableCell>{player.pointsWon - player.pointsLost}</TableCell>
                             <TableCell>{player.balance}</TableCell>
                         </TableRow>
                     ))}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,7 +22,10 @@ export type CourtState = {
   court: number;
   teamA: string[];
   teamB: string[];
-  result?: ResultMark;
+  /** Points scored by team A */
+  scoreA?: number;
+  /** Points scored by team B */
+  scoreB?: number;
 };
 
 export type TournamentState = {

--- a/frontend/src/utils/rotation.ts
+++ b/frontend/src/utils/rotation.ts
@@ -65,7 +65,7 @@ export function moveAndReform(
     const arrivals: Record<number, string[]> = {};
 
     for (const c of courts) {
-        const res = c.result as ResultMark;
+        const res: ResultMark = (c.scoreA ?? 0) > (c.scoreB ?? 0) ? 'A' : 'B';
         const winners = res === 'A' ? c.teamA : c.teamB;
         const losers = res === 'A' ? c.teamB : c.teamA;
 


### PR DESCRIPTION
## Summary
- record actual game scores and enforce 11-point, win-by-2 games across three rounds
- update player stats from scores and rank ties by point differential
- show score entry fields and point differential column in standings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4691245c0832d8a9739d4b14ede04