### PR TITLE
Allow starting tournaments with 12-40 players

### DIFF
--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -32,7 +32,7 @@ export const useTournament = create<Store>()(
             totalRounds: 3,
             entryFee: 30,
             started: false,
-            maxCourts: 3,
+            maxCourts: 10,
 
             addPlayer: (name, rating) =>
                 set((s) => {
@@ -69,7 +69,7 @@ export const useTournament = create<Store>()(
                 totalRounds: 3,
                 entryFee: 30,
                 started: false,
-                maxCourts: 3
+                maxCourts: 10
             })),
 
             setConfig: cfg =>
@@ -85,12 +85,12 @@ export const useTournament = create<Store>()(
 
             canStart: () => {
                 const s = get();
+                const count = s.players.length;
                 return (
                     !s.started &&
-                    s.players.length === 12 &&
-                    s.players.length % 4 === 0 &&
-                    get().requiredCourts() === 3 &&
-                    s.totalRounds === 3
+                    count >= 12 &&
+                    count <= 40 &&
+                    count % 4 === 0
                 );
             },
 


### PR DESCRIPTION
## Summary
- Allow starting tournaments once player count is a multiple of four between 12 and 40
- Support up to ten courts by default so all players are placed on courts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46b5dc688832d8734f19ffe41414f