### PR TITLE
Simplify setup and dynamic payouts

### DIFF
--- a/frontend/src/components/CourtsGrid.tsx
+++ b/frontend/src/components/CourtsGrid.tsx
@@ -44,20 +44,18 @@ export default function CourtsGrid() {
                                 <Stack direction="row" spacing={1}>
                                     <TextField
                                         label="A"
-                                        type="number"
                                         size="small"
                                         value={court.scoreA ?? ''}
                                         onChange={e => markResult(court.court, { scoreA: e.target.value === '' ? undefined : Number(e.target.value) })}
-                                        inputProps={{ min: 0 }}
+                                        inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
                                         sx={{ width: 60 }}
                                     />
                                     <TextField
                                         label="B"
-                                        type="number"
                                         size="small"
                                         value={court.scoreB ?? ''}
                                         onChange={e => markResult(court.court, { scoreB: e.target.value === '' ? undefined : Number(e.target.value) })}
-                                        inputProps={{ min: 0 }}
+                                        inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
                                         sx={{ width: 60 }}
                                     />
                                 </Stack>

--- a/frontend/src/components/SetupPanel.tsx
+++ b/frontend/src/components/SetupPanel.tsx
@@ -3,10 +3,7 @@ import { useTournament } from '../state/useTournament';
 
 export default function SetupPanel() {
     const {
-        maxCourts,
-        totalRounds,
         entryFee,
-        started,
         setConfig,
         startTournament,
         reset,
@@ -15,21 +12,7 @@ export default function SetupPanel() {
 
     return (
         <Stack spacing={1.5}>
-            <Typography variant="h6">Setup</Typography>
-            <TextField
-                label="Number of Courts"
-                type="number"
-                value={maxCourts}
-                disabled
-                size="small"
-            />
-            <TextField
-                label="Total Rounds"
-                type="number"
-                value={totalRounds}
-                disabled
-                size="small"
-            />
+            <Typography variant="h6">Tournament</Typography>
             <TextField
                 label="Entry Fee ($)"
                 type="number"

--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -206,11 +206,14 @@ export const useTournament = create<Store>()(
                 const s = get();
                 const totalPot = s.players.length * s.entryFee;
                 const payoutPool = totalPot * 0.5;
-                const payoutPercents = [50, 30, 20];
-                const places = payoutPercents.map((pct, i) => ({
+                const count = get().requiredCourts();
+                const base = count ? Math.floor(payoutPool / count) : 0;
+                const remainder = count ? payoutPool - base * count : 0;
+                const standings = get().standings();
+                const places = Array.from({ length: count }, (_, i) => ({
                     place: i + 1,
-                    player: get().standings()[i],
-                    amount: Math.round(payoutPool * (pct / 100))
+                    player: standings[i],
+                    amount: base + (i === 0 ? remainder : 0),
                 }));
                 return { totalPot, payoutPool, places };
             }


### PR DESCRIPTION
## Summary
- Remove number-of-courts and rounds inputs so entry fee is the only configurable item
- Use plain numeric inputs for court scores
- Compute payouts for as many places as there are courts, splitting the pool evenly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46f04fa8c832d9360a41b6f151e98