### PR TITLE
Allow courts to advance games independently

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,15 +34,14 @@ const words = [
 ]
 
 export default function App() {
-    const {started, round, game, totalRounds} = useTournament(s => ({
+    const { started, round, totalRounds } = useTournament(s => ({
         started: s.started,
         round: s.round,
-        game: s.game,
         totalRounds: s.totalRounds,
     }));
 
     const standingsLabel = started
-        ? `– Round ${round}, Game ${game}`
+        ? `– Round ${round}`
         : round >= totalRounds && round > 0
             ? '– Final Results'
             : '';

--- a/frontend/src/components/CourtsGrid.tsx
+++ b/frontend/src/components/CourtsGrid.tsx
@@ -39,7 +39,7 @@ export default function CourtsGrid() {
                     <Card variant="outlined">
                         <CardContent>
                             <Typography variant="subtitle1" fontWeight={700} gutterBottom>
-                                Court {court.court}
+                                Court {court.court} – Game {court.game}
                             </Typography>
                             <Stack spacing={1}>
                                 <Typography variant="body2">

--- a/frontend/src/components/RoundControls.tsx
+++ b/frontend/src/components/RoundControls.tsx
@@ -1,17 +1,13 @@
-import { Button, Chip, Stack, Typography } from '@mui/material';
+import { Chip, Stack, Typography } from '@mui/material';
 import { useTournament } from '../state/useTournament';
 
 export default function RoundControls() {
     const started = useTournament(s => s.started);
     const round = useTournament(s => s.round);
-    const game = useTournament(s => s.game);
     const totalRounds = useTournament(s => s.totalRounds);
-    const courts = useTournament(s => s.courts);
-    const nextGame = useTournament(s => s.nextGame);
 
-    const allResultsSubmitted = courts.length > 0 && courts.every(c => c.submitted);
     const statusLabel = started
-        ? `Round ${round} – Game ${game}`
+        ? `Round ${round}`
         : round >= totalRounds && round > 0
             ? 'Finished'
             : 'Not started';
@@ -21,11 +17,6 @@ export default function RoundControls() {
             <Stack direction="row" spacing={1} alignItems="center">
                 <Chip label={statusLabel} color={started ? 'primary' : 'default'} />
                 <Typography variant="body2" color="text.secondary">of {totalRounds} rounds</Typography>
-            </Stack>
-            <Stack direction="row" spacing={1}>
-                <Button onClick={nextGame} variant="contained" disabled={!started || !allResultsSubmitted}>
-                    Next Game
-                </Button>
             </Stack>
         </Stack>
     );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,8 @@ export type CourtState = {
   court: number;
   teamA: string[];
   teamB: string[];
+  /** Current game within the round (1-indexed) */
+  game: number;
   /** Points scored by team A */
   scoreA?: number;
   /** Points scored by team B */
@@ -34,8 +36,6 @@ export type TournamentState = {
   players: Player[];
   courts: CourtState[];
   round: number;
-  /** Current game within the round (1-indexed) */
-  game: number;
   totalRounds: number;
   entryFee: number;
   started: boolean;

--- a/frontend/src/utils/rotation.ts
+++ b/frontend/src/utils/rotation.ts
@@ -19,7 +19,7 @@ export function seedInitialCourts(players: Player[], courts: number): CourtState
         if (ids.length < 4) break;
         const teamA = [ids[0], ids[3]];
         const teamB = [ids[1], ids[2]];
-        grid.push({ court: c, teamA, teamB, submitted: false });
+        grid.push({ court: c, teamA, teamB, submitted: false, game: 1 });
     }
     return grid;
 }
@@ -81,11 +81,11 @@ export function moveAndReform(
         const ids = arrivals[c] ?? [];
         if (ids.length !== 4) {
             const prev = courts.find(k => k.court === c)!;
-            next.push({ court: c, teamA: prev.teamA.slice(), teamB: prev.teamB.slice(), submitted: false });
+            next.push({ court: c, teamA: prev.teamA.slice(), teamB: prev.teamB.slice(), submitted: false, game: 1 });
             continue;
         }
         const { A, B } = formTeamsAvoidingRepeat(ids, getPlayer);
-        next.push({ court: c, teamA: A, teamB: B, submitted: false });
+        next.push({ court: c, teamA: A, teamB: B, submitted: false, game: 1 });
     }
     return next;
 }


### PR DESCRIPTION
## Summary
- track current game on each court and drop global game counter
- rotate teams on a court immediately after submitting a score
- advance to next round only when all courts finish their games

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b476e5278c832d86fcabd3f26c67ab