### PR TITLE
Replace Vortex background with Meteors effect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import {Container, Stack, Typography} from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import SetupPanel from './components/SetupPanel';
 import PlayerList from './components/PlayerList';
@@ -6,13 +6,11 @@ import RoundControls from './components/RoundControls';
 import CourtsGrid from './components/CourtsGrid';
 import StandingsTable from './components/StandingsTable';
 import PayoutsTable from './components/PayoutsTable';
-import {useTournament} from './state/useTournament';
+import { useTournament } from './state/useTournament';
 import Panel from './components/Panel';
-import '../index.css'
 
 "use client";
-import {TypewriterEffectSmooth} from "./components/ui/typewriter-effect";
-import {Meteors} from "./components/ui/meteors";
+import { TypewriterEffectSmooth } from "./components/ui/typewriter-effect";
 
 const words = [
     {
@@ -47,11 +45,7 @@ export default function App() {
             : '';
 
     return (
-        <div style={{position: 'relative', minHeight: '100vh'}}>
-            <div style={{position: 'fixed', inset: 0, zIndex: -1, overflow: 'hidden'}}>
-                <Meteors number={30} />
-            </div>
-
+        <div>
             <Stack spacing={2} sx={{mb: 6}}>
                 <div style={{alignSelf: 'center'}}>
                     <TypewriterEffectSmooth words={words}/>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import {CssBaseline, ThemeProvider} from '@mui/material';
+import { CssBaseline, ThemeProvider } from '@mui/material';
 import theme from './theme';
 import "../index.css";
-import {Vortex} from "@/components/ui/vortex";
+import { Meteors } from "@/components/ui/meteors";
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <ThemeProvider theme={theme}>
-            <CssBaseline/>
-            <Vortex>
+            <CssBaseline />
+            <div style={{ position: 'relative', minHeight: '100vh' }}>
+                <div
+                    style={{
+                        position: 'fixed',
+                        inset: 0,
+                        zIndex: -1,
+                        overflow: 'hidden',
+                        background: 'black',
+                    }}
+                >
+                    <Meteors number={30} />
+                </div>
                 <App />
-            </Vortex>
+            </div>
         </ThemeProvider>
     </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Replace Vortex wrapper with Meteors component as full-screen background.
- Simplify App component to rely on the new global background.

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae1769e4832d877f2b3bf9210202