### PR TITLE
Ensure unique partners each round

### DIFF
--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -52,6 +52,7 @@ export const useTournament = create<Store>()(
                         rating,
                         court1Finishes: 0,
                         lastPartnerId: null,
+                        partnerHistory: [],
                         history: []
                     };
                     return { ...s, players: [...s.players, p] };
@@ -164,10 +165,10 @@ export const useTournament = create<Store>()(
 
                         const [a0, a1] = c.teamA;
                         const [b0, b1] = c.teamB;
-                        const pa0 = gp(a0); pa0.lastPartnerId = a1;
-                        const pa1 = gp(a1); pa1.lastPartnerId = a0;
-                        const pb0 = gp(b0); pb0.lastPartnerId = b1;
-                        const pb1 = gp(b1); pb1.lastPartnerId = b0;
+                        const pa0 = gp(a0); pa0.lastPartnerId = a1; pa0.partnerHistory.push(a1);
+                        const pa1 = gp(a1); pa1.lastPartnerId = a0; pa1.partnerHistory.push(a0);
+                        const pb0 = gp(b0); pb0.lastPartnerId = b1; pb0.partnerHistory.push(b1);
+                        const pb1 = gp(b1); pb1.lastPartnerId = b0; pb1.partnerHistory.push(b0);
 
                         if (c.game < GAMES_PER_ROUND) {
                             const participants = [...c.teamA, ...c.teamB];
@@ -183,15 +184,22 @@ export const useTournament = create<Store>()(
                     if (roundDone) {
                         let round = s.round + 1;
                         let started = s.started;
+                        const players = s.players.map(p => ({ ...p, partnerHistory: [] }));
+                        const gpRound = (id: string) => {
+                            const player = players.find(x => x.id === id);
+                            if (!player) throw new Error('player not found');
+                            return player;
+                        };
                         let nextCourts: CourtState[] = courts;
                         if (round > s.totalRounds) {
                             round = s.totalRounds;
                             started = false;
                         } else {
-                            nextCourts = moveAndReform(courts, gp).map(c => ({ ...c, game: 1 }));
+                            nextCourts = moveAndReform(courts, gpRound).map(c => ({ ...c, game: 1 }));
                         }
                         return {
                             ...s,
+                            players,
                             courts: nextCourts.map(c => ({
                                 ...c,
                                 scoreA: undefined,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,8 @@ export type Player = {
   rating: number;
   court1Finishes: number;
   lastPartnerId: string | null;
+  /** IDs of partners played with in the current round */
+  partnerHistory: string[];
   history: Array<{ round: number; court: number; team: 'A' | 'B'; result: 'W' | 'L' }>;
 };
 

--- a/frontend/src/utils/rotation.ts
+++ b/frontend/src/utils/rotation.ts
@@ -36,13 +36,17 @@ export function formTeamsAvoidingRepeat(
         [participants[0], participants[2], participants[1], participants[3]],
         [participants[0], participants[3], participants[1], participants[2]],
     ];
+    const penalty = (id1: string, id2: string) => {
+        const p = getPlayer(id1);
+        return p.lastPartnerId === id2 || p.partnerHistory.includes(id2) ? 1 : 0;
+    };
     const score = (combo: string[]) => {
         const a = [combo[0], combo[1]];
         const b = [combo[2], combo[3]];
-        const p0 = getPlayer(a[0]).lastPartnerId === a[1] ? 1 : 0;
-        const p1 = getPlayer(a[1]).lastPartnerId === a[0] ? 1 : 0;
-        const p2 = getPlayer(b[0]).lastPartnerId === b[1] ? 1 : 0;
-        const p3 = getPlayer(b[1]).lastPartnerId === b[0] ? 1 : 0;
+        const p0 = penalty(a[0], a[1]);
+        const p1 = penalty(a[1], a[0]);
+        const p2 = penalty(b[0], b[1]);
+        const p3 = penalty(b[1], b[0]);
         return p0 + p1 + p2 + p3;
     };
     let best = permutations[0];


### PR DESCRIPTION
## Summary
- Track partner history for players to avoid teaming with the same partner multiple times in a round
- Reset partner history between rounds and update team-forming logic to check it

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run build --prefix frontend`
- `cd backend && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c344413c832dbfcde490335c1c9a