### PR TITLE
Sort standings by points scored then differential

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,7 +10,7 @@ A React + TypeScript web app to run a **King-of-the-Court style pickleball tourn
 - Automatic payout calculations with customizable % split
 - Winner-up / loser-down rotation logic
 - Avoids repeat partners as much as possible
-- Standings tracked (points, wins, losses, Ct1 finishes)
+- Standings tracked (points scored, points against, Ct1 finishes)
 - CSV export of standings
 
 ## Getting Started

--- a/frontend/src/components/StandingsTable.tsx
+++ b/frontend/src/components/StandingsTable.tsx
@@ -10,13 +10,10 @@ export default function StandingsTable() {
 
     const exportStandings = () => {
         const rows: string[][] = [
-            ['Rank', 'Player', 'Points', 'Wins', 'Losses', 'Pts Won', 'Pts Lost', 'Diff', 'Balance'],
+            ['Rank', 'Player', 'Pts Won', 'Pts Lost', 'Diff', 'Balance'],
             ...standingsList.map((player, i) => [
                 String(i + 1),
                 player.name,
-                String(player.points),
-                String(player.wins),
-                String(player.losses),
                 String(player.pointsWon),
                 String(player.pointsLost),
                 String(player.pointsWon - player.pointsLost),
@@ -33,9 +30,6 @@ export default function StandingsTable() {
                     <TableRow>
                         <TableCell>#</TableCell>
                         <TableCell>Player</TableCell>
-                        <TableCell>Pts</TableCell>
-                        <TableCell>Wins</TableCell>
-                        <TableCell>Losses</TableCell>
                         <TableCell>Pts Won</TableCell>
                         <TableCell>Pts Lost</TableCell>
                         <TableCell>Diff</TableCell>
@@ -47,9 +41,6 @@ export default function StandingsTable() {
                         <TableRow key={player.id}>
                             <TableCell>{i + 1}</TableCell>
                             <TableCell>{player.name}</TableCell>
-                            <TableCell>{player.points}</TableCell>
-                            <TableCell>{player.wins}</TableCell>
-                            <TableCell>{player.losses}</TableCell>
                             <TableCell>{player.pointsWon}</TableCell>
                             <TableCell>{player.pointsLost}</TableCell>
                             <TableCell>{player.pointsWon - player.pointsLost}</TableCell>

--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -43,9 +43,6 @@ export const useTournament = create<Store>()(
                     const p: Player = {
                         id: generateId(),
                         name,
-                        points: 0,
-                        wins: 0,
-                        losses: 0,
                         pointsWon: 0,
                         pointsLost: 0,
                         balance: 0,
@@ -139,14 +136,11 @@ export const useTournament = create<Store>()(
                         const loserScore = res === 'A' ? scoreB : scoreA;
 
                         winners.forEach(p => {
-                            p.points += 2;
-                            p.wins++;
                             p.pointsWon += winnerScore;
                             p.pointsLost += loserScore;
                             p.history.push({ round: s.round, court: c.court, team: res, result: 'W' });
                         });
                         losers.forEach(p => {
-                            p.losses++;
                             p.pointsWon += loserScore;
                             p.pointsLost += winnerScore;
                             p.history.push({ round: s.round, court: c.court, team: res === 'A' ? 'B' : 'A', result: 'L' });
@@ -219,12 +213,10 @@ export const useTournament = create<Store>()(
                 const s = get();
                 const clone = s.players.slice();
                 clone.sort((a, b) => {
-                    if (b.points !== a.points) return b.points - a.points;
+                    if (b.pointsWon !== a.pointsWon) return b.pointsWon - a.pointsWon;
                     const diffA = a.pointsWon - a.pointsLost;
                     const diffB = b.pointsWon - b.pointsLost;
                     if (diffB !== diffA) return diffB - diffA;
-                    if (b.wins !== a.wins) return b.wins - a.wins;
-                    if (b.court1Finishes !== a.court1Finishes) return b.court1Finishes - a.court1Finishes;
                     return a.name.localeCompare(b.name);
                 });
                 return clone;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,10 +3,7 @@ export type ResultMark = 'A' | 'B';
 export type Player = {
   id: string;
   name: string;
-  points: number;
-  wins: number;
-  losses: number;
-  /** Total points earned from wins */
+  /** Total points scored by the player */
   pointsWon: number;
   /** Total points opponents earned against the player */
   pointsLost: number;


### PR DESCRIPTION
## Summary
- Drop win/loss and win-based points tracking from players
- Order standings by total points scored with point differential as tiebreaker
- Simplify standings table and CSV to show only points, points against, differential, and balance

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c51d5b58832d9c33dacb86e6c9a8