### PR TITLE
Add crown payouts for final-round court winners

### DIFF
--- a/frontend/src/components/PayoutsTable.tsx
+++ b/frontend/src/components/PayoutsTable.tsx
@@ -6,7 +6,7 @@ const formatCurrency = (n: number) => '$' + Math.round(n).toLocaleString();
 export default function PayoutsTable() {
     const entryFee = useTournament(s => s.entryFee);
     const playerCount = useTournament(s => s.players.length);
-    const { totalPot, payoutPool, places } = useTournament(s => s.payouts());
+    const { totalPot, payoutPool, awards } = useTournament(s => s.payouts());
     const poolPercent = totalPot ? Math.round((payoutPool / totalPot) * 100) : 0;
 
     if (!playerCount) return null;
@@ -22,17 +22,17 @@ export default function PayoutsTable() {
             <Table size="small">
                 <TableHead>
                     <TableRow>
-                        <TableCell>Place</TableCell>
+                        <TableCell>Crown</TableCell>
                         <TableCell>Player</TableCell>
                         <TableCell align="right">Amount</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {places.map(place => (
-                        <TableRow key={place.place}>
-                            <TableCell>{place.place}</TableCell>
-                            <TableCell>{place.player?.name ?? '—'}</TableCell>
-                            <TableCell align="right">{formatCurrency(place.amount)}</TableCell>
+                    {awards.map(a => (
+                        <TableRow key={a.court}>
+                            <TableCell>{a.crown}</TableCell>
+                            <TableCell>{a.player?.name ?? '—'}</TableCell>
+                            <TableCell align="right">{formatCurrency(a.amount)}</TableCell>
                         </TableRow>
                     ))}
                 </TableBody>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -40,3 +40,14 @@ export type TournamentState = {
   started: boolean;
   maxCourts: number;
 };
+
+export type CourtPayout = {
+  /** Court number for the prize */
+  court: number;
+  /** Display name of the prize */
+  crown: string;
+  /** Winning player for the court */
+  player?: Player;
+  /** Total payout amount */
+  amount: number;
+};


### PR DESCRIPTION
## Summary
- compute per-court payouts after final round and label top three courts as King's, Queen's, and Jack's Crowns
- expose court payout type and render crowns in payouts table

## Testing
- `npm test --prefix frontend` *(fails: Missing script: "test")*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b4ce197fb8832da537397e9220b72c