### PR TITLE
Fix missing court history causing white screen

### DIFF
--- a/frontend/src/components/CourtsGrid.tsx
+++ b/frontend/src/components/CourtsGrid.tsx
@@ -49,7 +49,7 @@ export default function CourtsGrid() {
                                 <Typography variant="body2">
                                     <strong>B:</strong> {formatTeam(court.teamB)}
                                 </Typography>
-                                {court.history.map(g => (
+                                {(court.history ?? []).map(g => (
                                     <Stack key={g.game} direction="row" spacing={1} alignItems="center">
                                         <Typography variant="body2">Game {g.game}</Typography>
                                         <TextField

--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -371,6 +371,24 @@ export const useTournament = create<Store>()(
                 return { totalPot, payoutPool, awards };
             }
         }),
-        { name: 'kotc10' }
+        {
+            name: 'kotc10',
+            merge: (persisted, current) => {
+                const merged = {
+                    ...current,
+                    ...(persisted as Partial<TournamentState>),
+                } as TournamentState;
+                merged.players = (merged.players ?? []).map((p: Player) => ({
+                    ...p,
+                    partnerHistory: p.partnerHistory ?? [],
+                    history: p.history ?? [],
+                }));
+                merged.courts = (merged.courts ?? []).map((c: CourtState) => ({
+                    ...c,
+                    history: c.history ?? [],
+                }));
+                return merged;
+            },
+        }
     )
 );


### PR DESCRIPTION
## Summary
- handle rehydrating courts lacking `history` to avoid crashes
- guard court history rendering against undefined values

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b590f50ea0832d9633576a0529324c