### PR TITLE
fix: ensure tournament store exposes matches field

### DIFF
--- a/frontend/src/state/useTournament.ts
+++ b/frontend/src/state/useTournament.ts
@@ -8,7 +8,7 @@ const generateId = () =>
 
 const GAMES_PER_ROUND = 3;
 
-type Store = TournamentState & {
+interface Store extends TournamentState {
     addPlayer: (name: string, rating: number) => void;
     removePlayer: (id: string) => void;
     reset: () => void;
@@ -24,7 +24,7 @@ type Store = TournamentState & {
     canStart: () => boolean;
     requiredCourts: () => number;
     getPlayer: (id: string) => Player;
-};
+}
 
 export const useTournament = create<Store>()(
     persist(


### PR DESCRIPTION
## Summary
- refactor zustand tournament store to use an interface extending `TournamentState`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b5d022c79c832d9bee39a77354f9e3