### PR TITLE
Add 3D card landing buttons and improve pickleball background

### DIFF
--- a/frontend/src/assets/pickleball.svg
+++ b/frontend/src/assets/pickleball.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <circle cx="50" cy="50" r="50" fill="#FDE047"/>
+  <circle cx="30" cy="30" r="7" fill="#000"/>
+  <circle cx="70" cy="30" r="7" fill="#000"/>
+  <circle cx="50" cy="50" r="7" fill="#000"/>
+  <circle cx="30" cy="70" r="7" fill="#000"/>
+  <circle cx="70" cy="70" r="7" fill="#000"/>
+</svg>

--- a/frontend/src/components/ui/3d-card.tsx
+++ b/frontend/src/components/ui/3d-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+import { motion, useMotionValue, useTransform } from "motion/react";
+import { cn } from "@/lib/utils";
+
+export const CardContainer = ({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: React.ReactNode;
+}) => {
+  return (
+    <div className={cn("[perspective:1000px]", className)}>{children}</div>
+  );
+};
+
+export const CardBody = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, children, ...props }, ref) => {
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const rotateX = useTransform(y, [-0.5, 0.5], [10, -10]);
+  const rotateY = useTransform(x, [-0.5, 0.5], [-10, 10]);
+
+  function handleMouseMove(event: React.MouseEvent<HTMLDivElement>) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const px = (event.clientX - rect.left) / rect.width - 0.5;
+    const py = (event.clientY - rect.top) / rect.height - 0.5;
+    x.set(px);
+    y.set(py);
+  }
+
+  function handleMouseLeave() {
+    x.set(0);
+    y.set(0);
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      className={cn("relative [transform-style:preserve-3d]", className)}
+      style={{ rotateX, rotateY }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+});
+CardBody.displayName = "CardBody";
+
+export const CardItem = ({
+  as: Component = "div",
+  translateZ = 0,
+  className,
+  children,
+  ...props
+}: {
+  as?: React.ElementType;
+  translateZ?: number | string;
+  className?: string;
+  children?: React.ReactNode;
+} & React.HTMLAttributes<HTMLElement>) => {
+  return (
+    <Component
+      className={cn("[transform-style:preserve-3d]", className)}
+      style={{ transform: `translateZ(${translateZ}px)` }}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+};

--- a/frontend/src/components/ui/pickleballs.tsx
+++ b/frontend/src/components/ui/pickleballs.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import { motion } from "motion/react";
 import React from "react";
+import pickleball from "@/assets/pickleball.svg";
 
 export const Pickleballs = ({
   number,
@@ -19,27 +20,26 @@ export const Pickleballs = ({
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      {balls.map((_, idx) => {
-        const count = number || 20;
-        const position = idx * (800 / count) - 400;
-
-        return (
-          <span
-            key={"pickleball" + idx}
-            className={cn(
-              "animate-pickleball absolute h-3 w-3 rounded-full bg-yellow-300 shadow-[0_0_10px_rgba(251,191,36,0.8)]",
-              className,
-            )}
-            style={{
-              top: "-40px",
-              left: position + "px",
-              animationDelay: Math.random() * 5 + "s",
-              animationDuration: Math.floor(Math.random() * (10 - 5) + 5) + "s",
-            }}
-          />
-        );
-      })}
-    </motion.div>
-  );
-};
+        {balls.map((_, idx) => {
+          return (
+            <img
+              key={"pickleball" + idx}
+              src={pickleball}
+              alt="pickleball"
+              className={cn(
+                "animate-pickleball absolute h-6 w-6",
+                className,
+              )}
+              style={{
+                top: "-40px",
+                left: Math.random() * 100 + "%",
+                animationDelay: Math.random() * 5 + "s",
+                animationDuration: Math.floor(Math.random() * (10 - 5) + 5) + "s",
+              }}
+            />
+          );
+        })}
+      </motion.div>
+    );
+  };
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,6 +1,7 @@
-import { Button, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { CardBody, CardContainer, CardItem } from '@/components/ui/3d-card';
 
 export default function LandingPage() {
   const navigate = useNavigate();
@@ -16,28 +17,32 @@ export default function LandingPage() {
         Smashboard
       </Typography>
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={4}>
-        <Button
-          variant="contained"
-          color="primary"
-          size="large"
-          sx={{ width: 220, height: 100, fontSize: '1.2rem' }}
-          onClick={() => navigate('/snl')}
-        >
-          SNL
-          <br />
-          Saturday Night Lights
-        </Button>
-        <Button
-          variant="contained"
-          color="secondary"
-          size="large"
-          sx={{ width: 220, height: 100, fontSize: '1.2rem' }}
-          onClick={() => navigate('/smb')}
-        >
-          SMB
-          <br />
-          Senior Money Ball
-        </Button>
+        <CardContainer>
+          <CardBody
+            className="group/card flex h-[100px] w-[220px] cursor-pointer flex-col items-center justify-center rounded-xl bg-blue-600 text-white"
+            onClick={() => navigate('/snl')}
+          >
+            <CardItem translateZ={50} className="text-xl font-bold">
+              SNL
+            </CardItem>
+            <CardItem translateZ={60} className="mt-2 text-sm text-center">
+              Saturday Night Lights
+            </CardItem>
+          </CardBody>
+        </CardContainer>
+        <CardContainer>
+          <CardBody
+            className="group/card flex h-[100px] w-[220px] cursor-pointer flex-col items-center justify-center rounded-xl bg-pink-600 text-white"
+            onClick={() => navigate('/smb')}
+          >
+            <CardItem translateZ={50} className="text-xl font-bold">
+              SMB
+            </CardItem>
+            <CardItem translateZ={60} className="mt-2 text-sm text-center">
+              Senior Money Ball
+            </CardItem>
+          </CardBody>
+        </CardContainer>
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Replace landing page buttons with interactive 3D cards for SNL and SMB navigation.
- Introduce reusable 3D card component.
- Enhance background animation with full-width pickleball SVGs.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d87196a8832da27c972a5efd806f