### PR TITLE
feat: speed up spinning pickleballs

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -122,9 +122,18 @@
 
 @layer utilities {
   @keyframes pickleball-fall {
-    0% { transform: translateY(-50px) scale(1); opacity: 1; }
-    90% { transform: translateY(100vh) scale(1); opacity: 1; }
-    100% { transform: translateY(100vh) scale(1.5); opacity: 0; }
+    0% {
+      transform: translateY(-50px) rotate(0deg) scale(1);
+      opacity: 1;
+    }
+    90% {
+      transform: translateY(100vh) rotate(270deg) scale(1);
+      opacity: 1;
+    }
+    100% {
+      transform: translateY(100vh) rotate(360deg) scale(1.5);
+      opacity: 0;
+    }
   }
   .animate-pickleball {
     animation: pickleball-fall linear infinite;

--- a/frontend/src/components/ui/pickleballs.tsx
+++ b/frontend/src/components/ui/pickleballs.tsx
@@ -34,7 +34,7 @@ export const Pickleballs = ({
                 top: "-40px",
                 left: Math.random() * 100 + "%",
                 animationDelay: Math.random() * 5 + "s",
-                animationDuration: Math.floor(Math.random() * (10 - 5) + 5) + "s",
+                animationDuration: Math.random() * 3 + 2 + "s",
               }}
             />
           );


### PR DESCRIPTION
## Summary
- spin falling background pickleballs
- increase pickleball fall speed for lively background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d9f9b2ec832d851b685dff45db15