### PR TITLE
Add Moneyball tournament mode with buy-in payouts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,30 +9,25 @@ import PayoutsTable from './components/PayoutsTable';
 import MatchScoresTable from './components/MatchScoresTable';
 import { useTournament } from './state/useTournament';
 import Panel from './components/Panel';
+import { useLocation } from 'react-router-dom';
 
 "use client";
 import { TypewriterEffectSmooth } from "./components/ui/typewriter-effect";
 
-const words = [
-    {
-        text: "King",
-        className: "text-blue-500 dark:text-blue-500"
-    },
-    {
-        text: "of",
-        className: "text-blue-500 dark:text-blue-500"
-    },
-    {
-        text: "the",
-        className: "text-blue-500 dark:text-blue-500"
-    },
-    {
-        text: "Court",
-        className: "text-blue-500 dark:text-blue-500"
-    }
-]
-
 export default function App() {
+    const location = useLocation();
+    const isSmb = location.pathname.startsWith('/smb');
+    const words = isSmb
+        ? [
+            { text: 'Money', className: 'text-pink-500 dark:text-pink-500' },
+            { text: 'Ball', className: 'text-pink-500 dark:text-pink-500' },
+        ]
+        : [
+            { text: 'King', className: 'text-blue-500 dark:text-blue-500' },
+            { text: 'of', className: 'text-blue-500 dark:text-blue-500' },
+            { text: 'the', className: 'text-blue-500 dark:text-blue-500' },
+            { text: 'Court', className: 'text-blue-500 dark:text-blue-500' },
+        ];
     const { started, round, totalRounds } = useTournament(s => ({
         started: s.started,
         round: s.round,
@@ -52,7 +47,7 @@ export default function App() {
                     <TypewriterEffectSmooth words={words}/>
                 </div>
                 <Typography style={{alignSelf: 'center'}} variant="body2" color="text.secondary">
-                    Where Every Court Pays Out!
+                    {isSmb ? 'Moneyball Madness!' : 'Where Every Court Pays Out!'}
                 </Typography>
             </Stack>
 

--- a/frontend/src/components/PayoutsTable.tsx
+++ b/frontend/src/components/PayoutsTable.tsx
@@ -1,12 +1,19 @@
 import { Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { useLocation } from 'react-router-dom';
 import { useTournament } from '../state/useTournament';
 
 const formatCurrency = (n: number) => '$' + Math.round(n).toLocaleString();
 
 export default function PayoutsTable() {
-    const entryFee = useTournament(s => s.entryFee);
-    const playerCount = useTournament(s => s.players.length);
-    const { totalPot, payoutPool, awards } = useTournament(s => s.payouts());
+    const location = useLocation();
+    const isSmb = location.pathname.startsWith('/smb');
+    const fee = useTournament(s => (isSmb ? s.buyInFee : s.entryFee));
+    const playerCount = useTournament(s =>
+        isSmb ? s.players.filter(p => p.buyIn).length : s.players.length
+    );
+    const { totalPot, payoutPool, awards } = useTournament(s =>
+        isSmb ? s.moneyballPayouts() : s.payouts()
+    );
     const poolPercent = totalPot ? Math.round((payoutPool / totalPot) * 100) : 0;
 
     if (!playerCount) return null;
@@ -15,22 +22,22 @@ export default function PayoutsTable() {
         <Stack spacing={1}>
             <Typography variant="h6">Payouts</Typography>
             <Typography variant="body2" color="text.secondary">
-                {playerCount} players × ${entryFee} entry ={' '}
+                {playerCount} players × ${fee} {isSmb ? 'buy-in' : 'entry'} ={' '}
                 <strong>{formatCurrency(totalPot)}</strong> | Payout pool ({poolPercent}%):{' '}
                 <strong>{formatCurrency(payoutPool)}</strong>
             </Typography>
             <Table size="small">
                 <TableHead>
                     <TableRow>
-                        <TableCell>Crown</TableCell>
+                        <TableCell>{isSmb ? 'Place' : 'Crown'}</TableCell>
                         <TableCell>Player</TableCell>
                         <TableCell align="right">Amount</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
                     {awards.map(a => (
-                        <TableRow key={a.court}>
-                            <TableCell>{a.crown}</TableCell>
+                        <TableRow key={isSmb ? a.place : a.court}>
+                            <TableCell>{isSmb ? `${a.place}º` : a.crown}</TableCell>
                             <TableCell>{a.player?.name ?? '—'}</TableCell>
                             <TableCell align="right">{formatCurrency(a.amount)}</TableCell>
                         </TableRow>

--- a/frontend/src/components/PlayerList.tsx
+++ b/frontend/src/components/PlayerList.tsx
@@ -7,18 +7,23 @@ import {
     ListItem,
     ListItemSecondaryAction,
     ListItemText,
+    Checkbox,
     Stack,
     TextField,
     Typography,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useTournament } from '../state/useTournament';
 
 export default function PlayerList() {
+    const location = useLocation();
+    const isSmb = location.pathname.startsWith('/smb');
     const players = useTournament(s => s.players);
     const add = useTournament(s => s.addPlayer);
     const remove = useTournament(s => s.removePlayer);
+    const toggleBuyIn = useTournament(s => s.toggleBuyIn);
     const started = useTournament(s => s.started);
 
     type DbPlayer = { name: string; rating: number };
@@ -101,6 +106,14 @@ export default function PlayerList() {
                 {players.map(player => (
                     <ListItem key={player.id} secondaryAction={
                         <ListItemSecondaryAction>
+                            {isSmb && (
+                                <Checkbox
+                                    edge="start"
+                                    checked={!!player.buyIn}
+                                    onChange={() => toggleBuyIn(player.id)}
+                                    disabled={started}
+                                />
+                            )}
                             <IconButton edge="end" onClick={() => remove(player.id)} disabled={started}>
                                 <DeleteIcon />
                             </IconButton>

--- a/frontend/src/components/SetupPanel.tsx
+++ b/frontend/src/components/SetupPanel.tsx
@@ -1,9 +1,13 @@
 import { Button, Stack, TextField, Typography } from '@mui/material';
+import { useLocation } from 'react-router-dom';
 import { useTournament } from '../state/useTournament';
 
 export default function SetupPanel() {
+    const location = useLocation();
+    const isSmb = location.pathname.startsWith('/smb');
     const {
         entryFee,
+        buyInFee,
         setConfig,
         startTournament,
         reset,
@@ -14,10 +18,16 @@ export default function SetupPanel() {
         <Stack spacing={1.5}>
             <Typography variant="h6">Tournament</Typography>
             <TextField
-                label="Entry Fee ($)"
+                label={isSmb ? "Buy-In Fee ($)" : "Entry Fee ($)"}
                 type="number"
-                value={entryFee}
-                onChange={e => setConfig({ entryFee: Math.max(0, Number(e.target.value || 30)) })}
+                value={isSmb ? buyInFee : entryFee}
+                onChange={e =>
+                    setConfig(
+                        isSmb
+                            ? { buyInFee: Math.max(0, Number(e.target.value || 20)) }
+                            : { entryFee: Math.max(0, Number(e.target.value || 30)) }
+                    )
+                }
                 size="small"
             />
             <Stack direction="row" spacing={1}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,6 +13,8 @@ export type Player = {
   /** IDs of partners played with in the current round */
   partnerHistory: string[];
   history: Array<{ round: number; court: number; game: number; team: 'A' | 'B'; result: 'W' | 'L' }>;
+  /** Whether this player paid the buy-in for Moneyball */
+  buyIn?: boolean;
 };
 
 export type CourtGame = {
@@ -49,6 +51,8 @@ export type TournamentState = {
   round: number;
   totalRounds: number;
   entryFee: number;
+  /** Buy-in amount for Moneyball tournaments */
+  buyInFee: number;
   started: boolean;
   maxCourts: number;
   matches: CourtGame[];


### PR DESCRIPTION
## Summary
- add Moneyball buy-in support and payouts for `/smb` route
- allow marking players as buy-ins and configuring buy-in fee
- display Moneyball prize pool and standings with existing layout

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68b60f52d3d0832d8d37b06242ad2ad8