### PR TITLE
Separate tournament state and persist to database

### DIFF
--- a/backend/src/main/java/com/example/smashboard/controller/TournamentStateController.java
+++ b/backend/src/main/java/com/example/smashboard/controller/TournamentStateController.java
@@ -1,0 +1,30 @@
+package com.example.smashboard.controller;
+
+import com.example.smashboard.service.TournamentStateService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/state")
+@CrossOrigin
+public class TournamentStateController {
+    private final TournamentStateService service;
+
+    public TournamentStateController(TournamentStateService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<String> get(@PathVariable String id) {
+        String data = service.getState(id);
+        if (data == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(data);
+    }
+
+    @PostMapping("/{id}")
+    public ResponseEntity<Void> save(@PathVariable String id, @RequestBody String data) {
+        service.saveState(id, data);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/backend/src/main/java/com/example/smashboard/model/TournamentState.java
+++ b/backend/src/main/java/com/example/smashboard/model/TournamentState.java
@@ -1,0 +1,38 @@
+package com.example.smashboard.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+@Entity
+public class TournamentState {
+    @Id
+    private String id;
+
+    @Lob
+    private String data;
+
+    public TournamentState() {}
+
+    public TournamentState(String id, String data) {
+        this.id = id;
+        this.data = data;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+}
+

--- a/backend/src/main/java/com/example/smashboard/repository/TournamentStateRepository.java
+++ b/backend/src/main/java/com/example/smashboard/repository/TournamentStateRepository.java
@@ -1,0 +1,8 @@
+package com.example.smashboard.repository;
+
+import com.example.smashboard.model.TournamentState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TournamentStateRepository extends JpaRepository<TournamentState, String> {
+}
+

--- a/backend/src/main/java/com/example/smashboard/service/TournamentStateService.java
+++ b/backend/src/main/java/com/example/smashboard/service/TournamentStateService.java
@@ -1,0 +1,7 @@
+package com.example.smashboard.service;
+
+public interface TournamentStateService {
+    void saveState(String id, String data);
+    String getState(String id);
+}
+

--- a/backend/src/main/java/com/example/smashboard/service/TournamentStateServiceImpl.java
+++ b/backend/src/main/java/com/example/smashboard/service/TournamentStateServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.smashboard.service;
+
+import com.example.smashboard.model.TournamentState;
+import com.example.smashboard.repository.TournamentStateRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TournamentStateServiceImpl implements TournamentStateService {
+    private final TournamentStateRepository repo;
+
+    public TournamentStateServiceImpl(TournamentStateRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public void saveState(String id, String data) {
+        repo.save(new TournamentState(id, data));
+    }
+
+    @Override
+    public String getState(String id) {
+        return repo.findById(id).map(TournamentState::getData).orElse(null);
+    }
+}
+

--- a/frontend/src/components/PlayerList.tsx
+++ b/frontend/src/components/PlayerList.tsx
@@ -25,6 +25,7 @@ export default function PlayerList() {
     const remove = useTournament(s => s.removePlayer);
     const toggleBuyIn = useTournament(s => s.toggleBuyIn);
     const started = useTournament(s => s.started);
+    const buyInFee = useTournament(s => s.buyInFee);
 
     type DbPlayer = { name: string; rating: number };
     const [query, setQuery] = useState('');
@@ -65,7 +66,14 @@ export default function PlayerList() {
 
     return (
         <Stack spacing={3.0}>
-            <Typography variant="h6">Players ({players.length})</Typography>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Players ({players.length})</Typography>
+                {isSmb && (
+                    <Typography variant="body2" color="text.secondary">
+                        Moneyball Buy-In (${buyInFee})
+                    </Typography>
+                )}
+            </Stack>
             <Stack direction="row" spacing={1}>
                 <Autocomplete<DbPlayer>
                     options={options}
@@ -106,17 +114,19 @@ export default function PlayerList() {
                 {players.map(player => (
                     <ListItem key={player.id} secondaryAction={
                         <ListItemSecondaryAction>
-                            {isSmb && (
-                                <Checkbox
-                                    edge="start"
-                                    checked={!!player.buyIn}
-                                    onChange={() => toggleBuyIn(player.id)}
-                                    disabled={started}
-                                />
-                            )}
-                            <IconButton edge="end" onClick={() => remove(player.id)} disabled={started}>
-                                <DeleteIcon />
-                            </IconButton>
+                            <Stack direction="row" alignItems="center" spacing={1}>
+                                {isSmb && (
+                                    <Checkbox
+                                        edge="start"
+                                        checked={!!player.buyIn}
+                                        onChange={() => toggleBuyIn(player.id)}
+                                        disabled={started}
+                                    />
+                                )}
+                                <IconButton edge="end" onClick={() => remove(player.id)} disabled={started}>
+                                    <DeleteIcon />
+                                </IconButton>
+                            </Stack>
                         </ListItemSecondaryAction>
                     }>
                         <ListItemText primary={`${player.name} (${player.rating})`} />


### PR DESCRIPTION
## Summary
- align Moneyball checkboxes with delete icons and show buy-in label
- maintain separate SNL and SMB stores and sync state to backend
- add backend endpoints and entity to persist tournament state

## Testing
- `npm test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b6118f8ae0832dbefcebcd0f043182