### PR TITLE
feat: allow editing of submitted match scores

### DIFF
--- a/frontend/src/components/CourtsGrid.tsx
+++ b/frontend/src/components/CourtsGrid.tsx
@@ -97,7 +97,7 @@ export default function CourtsGrid() {
                                                 label="A"
                                                 size="small"
                                                 value={g.scoreA}
-                                                onChange={e => editGame(court.court, g.game, { scoreA: Number(e.target.value) })}
+                                                onChange={e => editGame(g.round, court.court, g.game, { scoreA: Number(e.target.value) })}
                                                 inputProps={{ inputMode: 'numeric', pattern: '[0-9]*', min: 0, max: 11 }}
                                                 sx={scoreInputSx}
                                             />
@@ -105,7 +105,7 @@ export default function CourtsGrid() {
                                                 label="B"
                                                 size="small"
                                                 value={g.scoreB}
-                                                onChange={e => editGame(court.court, g.game, { scoreB: Number(e.target.value) })}
+                                                onChange={e => editGame(g.round, court.court, g.game, { scoreB: Number(e.target.value) })}
                                                 inputProps={{ inputMode: 'numeric', pattern: '[0-9]*', min: 0, max: 11 }}
                                                 sx={scoreInputSx}
                                             />

--- a/frontend/src/components/MatchScoresTable.tsx
+++ b/frontend/src/components/MatchScoresTable.tsx
@@ -1,10 +1,18 @@
-import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography, TextField, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { useTournament } from '@/state/useTournament';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 export default function MatchScoresTable() {
     const matches = useTournament(s => s.matches);
     const players = useTournament(s => s.players);
+    const editGame = useTournament(s => s.editGameScore);
+
+    const [editIdx, setEditIdx] = useState<number | null>(null);
+    const [scoreA, setScoreA] = useState('');
+    const [scoreB, setScoreB] = useState('');
 
     const nameMap = useMemo(() => {
         const map: Record<string, string> = {};
@@ -15,6 +23,21 @@ export default function MatchScoresTable() {
     if (!matches.length) return null;
 
     const formatTeam = (ids: string[]) => ids.map(id => nameMap[id] ?? 'Unknown').join(' & ');
+
+    const startEdit = (idx: number) => {
+        const m = matches[idx];
+        setEditIdx(idx);
+        setScoreA(String(m.scoreA));
+        setScoreB(String(m.scoreB));
+    };
+
+    const cancelEdit = () => setEditIdx(null);
+
+    const saveEdit = (idx: number) => {
+        const m = matches[idx];
+        editGame(m.round, m.court, m.game, { scoreA: Number(scoreA), scoreB: Number(scoreB) });
+        setEditIdx(null);
+    };
 
     return (
         <>
@@ -30,6 +53,7 @@ export default function MatchScoresTable() {
                         <TableCell>Team A</TableCell>
                         <TableCell>Score</TableCell>
                         <TableCell>Team B</TableCell>
+                        <TableCell></TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -39,8 +63,46 @@ export default function MatchScoresTable() {
                             <TableCell>{m.court}</TableCell>
                             <TableCell>{m.game}</TableCell>
                             <TableCell>{formatTeam(m.teamA)}</TableCell>
-                            <TableCell>{m.scoreA} - {m.scoreB}</TableCell>
+                            <TableCell>
+                                {editIdx === i ? (
+                                    <>
+                                        <TextField
+                                            size="small"
+                                            value={scoreA}
+                                            onChange={e => setScoreA(e.target.value)}
+                                            inputProps={{ inputMode: 'numeric', pattern: '[0-9]*', min: 0, max: 11 }}
+                                            sx={{ width: 40 }}
+                                        />
+                                        {' - '}
+                                        <TextField
+                                            size="small"
+                                            value={scoreB}
+                                            onChange={e => setScoreB(e.target.value)}
+                                            inputProps={{ inputMode: 'numeric', pattern: '[0-9]*', min: 0, max: 11 }}
+                                            sx={{ width: 40 }}
+                                        />
+                                    </>
+                                ) : (
+                                    `${m.scoreA} - ${m.scoreB}`
+                                )}
+                            </TableCell>
                             <TableCell>{formatTeam(m.teamB)}</TableCell>
+                            <TableCell>
+                                {editIdx === i ? (
+                                    <>
+                                        <IconButton color="success" size="small" onClick={() => saveEdit(i)}>
+                                            <CheckIcon />
+                                        </IconButton>
+                                        <IconButton color="error" size="small" onClick={cancelEdit}>
+                                            <CloseIcon />
+                                        </IconButton>
+                                    </>
+                                ) : (
+                                    <IconButton size="small" onClick={() => startEdit(i)}>
+                                        <EditIcon />
+                                    </IconButton>
+                                )}
+                            </TableCell>
                         </TableRow>
                     ))}
                 </TableBody>


### PR DESCRIPTION
## Summary
- allow match scores to be modified after submission
- update CourtsGrid to call revised edit function
- extend tournament state to update players and matches when scores change

## Testing
- `npm test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b89608ef34832db6297617e3f5d36e