### PR TITLE
Add tournament sidebar with rules and announcements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import MatchScoresTable from './components/MatchScoresTable';
 import { useTournament } from './state/useTournament';
 import Panel from './components/Panel';
 import { useLocation } from 'react-router-dom';
+import TournamentSidebar from './components/TournamentSidebar';
 
 "use client";
 import { TypewriterEffectSmooth } from "./components/ui/typewriter-effect";
@@ -41,53 +42,56 @@ export default function App() {
             : '';
 
     return (
-        <div>
-            <Stack spacing={2} sx={{mb: 6}}>
-                <div style={{alignSelf: 'center'}}>
-                    <TypewriterEffectSmooth words={words}/>
-                </div>
-                <Typography style={{alignSelf: 'center'}} variant="body2" color="text.secondary">
-                    {isSmb ? 'Moneyball Madness!' : 'Where Every Court Pays Out!'}
-                </Typography>
-            </Stack>
+        <div className="flex">
+            <TournamentSidebar />
+            <div className="flex-1">
+                <Stack spacing={2} sx={{mb: 6}}>
+                    <div style={{alignSelf: 'center'}}>
+                        <TypewriterEffectSmooth words={words}/>
+                    </div>
+                    <Typography style={{alignSelf: 'center'}} variant="body2" color="text.secondary">
+                        {isSmb ? 'Moneyball Madness!' : 'Where Every Court Pays Out!'}
+                    </Typography>
+                </Stack>
 
-            <Grid container spacing={2}>
-                <Grid padding={5} xs={12} md={4}>
-                    <Panel>
-                        <SetupPanel/>
-                    </Panel>
-                    <Panel sx={{mt: 2}}>
-                        <PlayerList/>
-                    </Panel>
-                </Grid>
+                <Grid container spacing={2}>
+                    <Grid padding={5} xs={12} md={4}>
+                        <Panel>
+                            <SetupPanel/>
+                        </Panel>
+                        <Panel sx={{mt: 2}}>
+                            <PlayerList/>
+                        </Panel>
+                    </Grid>
 
-                <Grid padding={5} xs={12} md={8}>
-                    <Panel>
-                        <RoundControls/>
-                        {!started && (
-                            <Typography mt={2} color="text.secondary">
-                                Add 12-40 players (multiple of 4), set rounds, then Start Tournament.
+                    <Grid padding={5} xs={12} md={8}>
+                        <Panel>
+                            <RoundControls/>
+                            {!started && (
+                                <Typography mt={2} color="text.secondary">
+                                    Add 12-40 players (multiple of 4), set rounds, then Start Tournament.
+                                </Typography>
+                            )}
+                            <CourtsGrid/>
+                        </Panel>
+
+                        <Panel sx={{mt: 2}}>
+                            <Typography variant="h6" gutterBottom>
+                                Standings {standingsLabel}
                             </Typography>
-                        )}
-                        <CourtsGrid/>
-                    </Panel>
+                            <StandingsTable/>
+                        </Panel>
 
-                    <Panel sx={{mt: 2}}>
-                        <Typography variant="h6" gutterBottom>
-                            Standings {standingsLabel}
-                        </Typography>
-                        <StandingsTable/>
-                    </Panel>
+                        <Panel sx={{mt: 2}}>
+                            <MatchScoresTable/>
+                        </Panel>
 
-                    <Panel sx={{mt: 2}}>
-                        <MatchScoresTable/>
-                    </Panel>
-
-                    <Panel sx={{mt: 2}}>
-                        <PayoutsTable/>
-                    </Panel>
+                        <Panel sx={{mt: 2}}>
+                            <PayoutsTable/>
+                        </Panel>
+                    </Grid>
                 </Grid>
-            </Grid>
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/SetupPanel.tsx
+++ b/frontend/src/components/SetupPanel.tsx
@@ -1,6 +1,7 @@
 import { Button, Stack, TextField, Typography } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import { useTournament } from '../state/useTournament';
+import { useAnnouncements } from '../state/useAnnouncements';
 
 export default function SetupPanel() {
     const location = useLocation();
@@ -12,7 +13,21 @@ export default function SetupPanel() {
         startTournament,
         reset,
         canStart,
+        started,
+        round,
+        totalRounds,
+        players,
+        standings,
     } = useTournament();
+    const addAnnouncement = useAnnouncements(s => s.addAnnouncement);
+
+    const handleReset = () => {
+        if (!started && round === totalRounds && players.length > 0) {
+            const winners = standings().slice(0, 3).map(p => ({ name: p.name, score: p.pointsWon }));
+            addAnnouncement({ tournament: isSmb ? 'SMB' : 'SNL', winners });
+        }
+        reset();
+    };
 
     return (
         <Stack spacing={1.5}>
@@ -38,7 +53,7 @@ export default function SetupPanel() {
                 >
                     Start Tournament
                 </Button>
-                <Button variant="outlined" color="error" onClick={reset}>
+                <Button variant="outlined" color="error" onClick={handleReset}>
                     Reset
                 </Button>
             </Stack>

--- a/frontend/src/components/TournamentSidebar.tsx
+++ b/frontend/src/components/TournamentSidebar.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { useAnnouncements } from '@/state/useAnnouncements';
+
+export default function TournamentSidebar() {
+  const announcements = useAnnouncements((s) => s.announcements);
+
+  return (
+    <Sidebar>
+      <SidebarContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <Link
+              to="/"
+              className="flex w-full items-center rounded-md px-2 py-1 hover:bg-accent hover:text-accent-foreground"
+            >
+              Home
+            </Link>
+          </SidebarMenuItem>
+        </SidebarMenu>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Rules</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <ul className="list-disc pl-4 text-xs space-y-1">
+              <li>Games to 11 points.</li>
+              <li>Win by 2.</li>
+              <li>Switch sides at 6.</li>
+            </ul>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Announcements</SidebarGroupLabel>
+          <SidebarGroupContent>
+            {announcements.length === 0 && (
+              <p className="text-xs text-muted-foreground">No announcements yet.</p>
+            )}
+            {announcements.map((a) => (
+              <div key={a.id} className="mb-2">
+                <div className="text-xs font-medium">
+                  {a.tournament} – {new Date(a.date).toLocaleDateString()}
+                </div>
+                <ul className="ml-4 list-disc text-xs">
+                  {a.winners.map((w) => (
+                    <li key={w.name}>
+                      {w.name}: {w.score}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Sidebar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('flex h-screen w-64 flex-col border-r bg-background p-4 text-sm', className)}
+      {...props}
+    />
+  )
+);
+Sidebar.displayName = 'Sidebar';
+
+const SidebarContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-1 flex-col gap-6', className)} {...props} />
+  )
+);
+SidebarContent.displayName = 'SidebarContent';
+
+const SidebarGroup = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col gap-2', className)} {...props} />
+  )
+);
+SidebarGroup.displayName = 'SidebarGroup';
+
+const SidebarGroupLabel = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-xs font-medium uppercase text-muted-foreground', className)} {...props} />
+  )
+);
+SidebarGroupLabel.displayName = 'SidebarGroupLabel';
+
+const SidebarGroupContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col gap-1', className)} {...props} />
+  )
+);
+SidebarGroupContent.displayName = 'SidebarGroupContent';
+
+const SidebarMenu = React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>(
+  ({ className, ...props }, ref) => (
+    <ul ref={ref} className={cn('flex flex-col gap-1', className)} {...props} />
+  )
+);
+SidebarMenu.displayName = 'SidebarMenu';
+
+const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElement>>(
+  ({ className, ...props }, ref) => <li ref={ref} className={className} {...props} />
+);
+SidebarMenuItem.displayName = 'SidebarMenuItem';
+
+const SidebarMenuButton = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-accent hover:text-accent-foreground', className)}
+      {...props}
+    />
+  )
+);
+SidebarMenuButton.displayName = 'SidebarMenuButton';
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+};

--- a/frontend/src/state/useAnnouncements.ts
+++ b/frontend/src/state/useAnnouncements.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Announcement } from '@/types';
+
+interface AnnouncementStore {
+  announcements: Announcement[];
+  addAnnouncement: (announcement: Omit<Announcement, 'id' | 'date'>) => void;
+}
+
+const generateId = () =>
+  (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export const useAnnouncements = create<AnnouncementStore>()(
+  persist(
+    (set) => ({
+      announcements: [],
+      addAnnouncement: (announcement) =>
+        set((state) => ({
+          announcements: [
+            { id: generateId(), date: new Date().toISOString(), ...announcement },
+            ...state.announcements,
+          ],
+        })),
+    }),
+    { name: 'announcements' }
+  )
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -68,3 +68,14 @@ export type CourtPayout = {
   /** Total payout amount */
   amount: number;
 };
+
+export type Announcement = {
+  /** Unique id for the announcement */
+  id: string;
+  /** Tournament identifier (e.g. SNL or SMB) */
+  tournament: string;
+  /** ISO date when the announcement was created */
+  date: string;
+  /** Top players and their final scores */
+  winners: Array<{ name: string; score: number }>;
+};


### PR DESCRIPTION
## Summary
- Create reusable sidebar UI component and tournament sidebar with home, rules, and dynamic announcements
- Track announcements in persisted store and append winners after each completed tournament
- Integrate sidebar into tournament pages and capture results on reset

## Testing
- `npm test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b89ca45b00832da295f511e11e3f41