### PR TITLE
style: apply dark theme to sidebar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>King of the Court – 10 Courts</title>
   </head>
-  <body>
+  <body class="dark">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/components/TournamentSidebar.tsx
+++ b/frontend/src/components/TournamentSidebar.tsx
@@ -20,7 +20,7 @@ export default function TournamentSidebar() {
           <SidebarMenuItem>
             <Link
               to="/"
-              className="flex w-full items-center rounded-md px-2 py-1 hover:bg-accent hover:text-accent-foreground"
+              className="flex w-full items-center rounded-md px-2 py-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             >
               Home
             </Link>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -5,7 +5,10 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEle
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('flex h-screen w-64 flex-col border-r bg-background p-4 text-sm', className)}
+      className={cn(
+        'flex h-screen w-64 flex-col border-r border-sidebar-border bg-sidebar p-4 text-sidebar-foreground text-sm',
+        className,
+      )}
       {...props}
     />
   )
@@ -56,7 +59,10 @@ const SidebarMenuButton = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAt
   ({ className, ...props }, ref) => (
     <button
       ref={ref}
-      className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-accent hover:text-accent-foreground', className)}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        className,
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- enable dark styling across app by default
- style sidebar and links using sidebar-specific theme variables

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcca610fa4832d8ef92158db1454ed