### PR TITLE
Store tournament results and export DUPR CSV

### DIFF
--- a/backend/src/main/java/com/example/smashboard/controller/MatchResultController.java
+++ b/backend/src/main/java/com/example/smashboard/controller/MatchResultController.java
@@ -1,0 +1,71 @@
+package com.example.smashboard.controller;
+
+import com.example.smashboard.model.MatchResult;
+import com.example.smashboard.repository.MatchResultRepository;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/matches")
+@CrossOrigin
+public class MatchResultController {
+    private final MatchResultRepository repo;
+
+    public MatchResultController(MatchResultRepository repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping("/export/{tournamentId}")
+    public ResponseEntity<Resource> export(@PathVariable String tournamentId) throws IOException {
+        List<MatchResult> matches = repo.findByTournamentId(tournamentId);
+        ClassPathResource template = new ClassPathResource("club_match_csv_template.csv");
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(template.getInputStream(), StandardCharsets.UTF_8))) {
+            for (int i = 0; i < 10; i++) {
+                String line = reader.readLine();
+                if (line == null) break;
+                sb.append(line).append("\n");
+            }
+        }
+
+        DateTimeFormatter df = DateTimeFormatter.ISO_DATE;
+        for (MatchResult m : matches) {
+            String[] cols = new String[29];
+            Arrays.fill(cols, "");
+            cols[3] = "D"; // doubles
+            cols[4] = tournamentId;
+            cols[5] = m.getPlayedOn() != null ? m.getPlayedOn().format(df) : "";
+            cols[6] = m.getPlayerA1();
+            cols[7] = m.getPlayerA1DuprId();
+            cols[9] = m.getPlayerA2();
+            cols[10] = m.getPlayerA2DuprId();
+            cols[12] = m.getPlayerB1();
+            cols[13] = m.getPlayerB1DuprId();
+            cols[15] = m.getPlayerB2();
+            cols[16] = m.getPlayerB2DuprId();
+            cols[19] = Integer.toString(m.getScoreA());
+            cols[20] = Integer.toString(m.getScoreB());
+            sb.append(Arrays.stream(cols).map(c -> c == null ? "" : c).collect(Collectors.joining(","))).append("\n");
+        }
+
+        ByteArrayResource resource = new ByteArrayResource(sb.toString().getBytes(StandardCharsets.UTF_8));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=dupr_matches.csv")
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(resource);
+    }
+}

--- a/backend/src/main/java/com/example/smashboard/model/MatchResult.java
+++ b/backend/src/main/java/com/example/smashboard/model/MatchResult.java
@@ -1,0 +1,162 @@
+package com.example.smashboard.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"tournamentId", "round", "court", "game"}))
+public class MatchResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String tournamentId;
+    private int round;
+    private int court;
+    private int game;
+
+    private String playerA1;
+    private String playerA1DuprId;
+    private String playerA2;
+    private String playerA2DuprId;
+    private String playerB1;
+    private String playerB1DuprId;
+    private String playerB2;
+    private String playerB2DuprId;
+
+    private int scoreA;
+    private int scoreB;
+
+    private LocalDate playedOn;
+
+    public MatchResult() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTournamentId() {
+        return tournamentId;
+    }
+
+    public void setTournamentId(String tournamentId) {
+        this.tournamentId = tournamentId;
+    }
+
+    public int getRound() {
+        return round;
+    }
+
+    public void setRound(int round) {
+        this.round = round;
+    }
+
+    public int getCourt() {
+        return court;
+    }
+
+    public void setCourt(int court) {
+        this.court = court;
+    }
+
+    public int getGame() {
+        return game;
+    }
+
+    public void setGame(int game) {
+        this.game = game;
+    }
+
+    public String getPlayerA1() {
+        return playerA1;
+    }
+
+    public void setPlayerA1(String playerA1) {
+        this.playerA1 = playerA1;
+    }
+
+    public String getPlayerA1DuprId() {
+        return playerA1DuprId;
+    }
+
+    public void setPlayerA1DuprId(String playerA1DuprId) {
+        this.playerA1DuprId = playerA1DuprId;
+    }
+
+    public String getPlayerA2() {
+        return playerA2;
+    }
+
+    public void setPlayerA2(String playerA2) {
+        this.playerA2 = playerA2;
+    }
+
+    public String getPlayerA2DuprId() {
+        return playerA2DuprId;
+    }
+
+    public void setPlayerA2DuprId(String playerA2DuprId) {
+        this.playerA2DuprId = playerA2DuprId;
+    }
+
+    public String getPlayerB1() {
+        return playerB1;
+    }
+
+    public void setPlayerB1(String playerB1) {
+        this.playerB1 = playerB1;
+    }
+
+    public String getPlayerB1DuprId() {
+        return playerB1DuprId;
+    }
+
+    public void setPlayerB1DuprId(String playerB1DuprId) {
+        this.playerB1DuprId = playerB1DuprId;
+    }
+
+    public String getPlayerB2() {
+        return playerB2;
+    }
+
+    public void setPlayerB2(String playerB2) {
+        this.playerB2 = playerB2;
+    }
+
+    public String getPlayerB2DuprId() {
+        return playerB2DuprId;
+    }
+
+    public void setPlayerB2DuprId(String playerB2DuprId) {
+        this.playerB2DuprId = playerB2DuprId;
+    }
+
+    public int getScoreA() {
+        return scoreA;
+    }
+
+    public void setScoreA(int scoreA) {
+        this.scoreA = scoreA;
+    }
+
+    public int getScoreB() {
+        return scoreB;
+    }
+
+    public void setScoreB(int scoreB) {
+        this.scoreB = scoreB;
+    }
+
+    public LocalDate getPlayedOn() {
+        return playedOn;
+    }
+
+    public void setPlayedOn(LocalDate playedOn) {
+        this.playedOn = playedOn;
+    }
+}
+

--- a/backend/src/main/java/com/example/smashboard/repository/MatchResultRepository.java
+++ b/backend/src/main/java/com/example/smashboard/repository/MatchResultRepository.java
@@ -1,0 +1,13 @@
+package com.example.smashboard.repository;
+
+import com.example.smashboard.model.MatchResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MatchResultRepository extends JpaRepository<MatchResult, Long> {
+    boolean existsByTournamentIdAndRoundAndCourtAndGame(String tournamentId, int round, int court, int game);
+    List<MatchResult> findByTournamentId(String tournamentId);
+}

--- a/backend/src/main/java/com/example/smashboard/service/TournamentStateServiceImpl.java
+++ b/backend/src/main/java/com/example/smashboard/service/TournamentStateServiceImpl.java
@@ -1,20 +1,94 @@
 package com.example.smashboard.service;
 
+import com.example.smashboard.model.MatchResult;
 import com.example.smashboard.model.TournamentState;
+import com.example.smashboard.repository.MatchResultRepository;
+import com.example.smashboard.repository.PlayerRepository;
 import com.example.smashboard.repository.TournamentStateRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class TournamentStateServiceImpl implements TournamentStateService {
     private final TournamentStateRepository repo;
+    private final MatchResultRepository matchRepo;
+    private final PlayerRepository playerRepo;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public TournamentStateServiceImpl(TournamentStateRepository repo) {
+    public TournamentStateServiceImpl(TournamentStateRepository repo,
+                                      MatchResultRepository matchRepo,
+                                      PlayerRepository playerRepo) {
         this.repo = repo;
+        this.matchRepo = matchRepo;
+        this.playerRepo = playerRepo;
     }
 
     @Override
     public void saveState(String id, String data) {
         repo.save(new TournamentState(id, data));
+        try {
+            JsonNode root = objectMapper.readTree(data);
+            JsonNode matches = root.get("matches");
+            if (matches == null || !matches.isArray()) return;
+
+            Map<String, String> idToName = new HashMap<>();
+            JsonNode players = root.get("players");
+            if (players != null && players.isArray()) {
+                for (JsonNode p : players) {
+                    idToName.put(p.get("id").asText(), p.get("name").asText());
+                }
+            }
+
+            for (JsonNode m : matches) {
+                int round = m.get("round").asInt();
+                int court = m.get("court").asInt();
+                int game = m.get("game").asInt();
+                if (matchRepo.existsByTournamentIdAndRoundAndCourtAndGame(id, round, court, game)) continue;
+
+                MatchResult result = new MatchResult();
+                result.setTournamentId(id);
+                result.setRound(round);
+                result.setCourt(court);
+                result.setGame(game);
+                result.setScoreA(m.get("scoreA").asInt());
+                result.setScoreB(m.get("scoreB").asInt());
+                result.setPlayedOn(LocalDate.now());
+
+                List<String> teamA = objectMapper.convertValue(m.get("teamA"), new TypeReference<List<String>>(){});
+                List<String> teamB = objectMapper.convertValue(m.get("teamB"), new TypeReference<List<String>>(){});
+
+                if (teamA.size() > 0) {
+                    String name = idToName.get(teamA.get(0));
+                    result.setPlayerA1(name);
+                    playerRepo.findByName(name).ifPresent(p -> result.setPlayerA1DuprId(p.getDuprId()));
+                }
+                if (teamA.size() > 1) {
+                    String name = idToName.get(teamA.get(1));
+                    result.setPlayerA2(name);
+                    playerRepo.findByName(name).ifPresent(p -> result.setPlayerA2DuprId(p.getDuprId()));
+                }
+                if (teamB.size() > 0) {
+                    String name = idToName.get(teamB.get(0));
+                    result.setPlayerB1(name);
+                    playerRepo.findByName(name).ifPresent(p -> result.setPlayerB1DuprId(p.getDuprId()));
+                }
+                if (teamB.size() > 1) {
+                    String name = idToName.get(teamB.get(1));
+                    result.setPlayerB2(name);
+                    playerRepo.findByName(name).ifPresent(p -> result.setPlayerB2DuprId(p.getDuprId()));
+                }
+
+                matchRepo.save(result);
+            }
+        } catch (Exception ignored) {
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- persist match results with players, scores, and play dates
- parse tournament state to record unique matches automatically
- export recorded matches as DUPR-compatible CSV using resource template

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bd66182db0832d800e748d45d2db84